### PR TITLE
Add property preprocessors to `@fedify/vocab-tools` and normalize `Link` `icon`/`image`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -341,6 +341,30 @@ To be released.
 
 [#489]: https://github.com/fedify-dev/fedify/issues/489
 
+### @fedify/vocab-runtime
+
+ -  Added `PropertyPreprocessor`, `PropertyPreprocessorContext`, and `Json`
+    types for normalizing wire-level JSON-LD property values before the
+    generated range decoder runs.  [[#792]]
+
+[#792]: https://github.com/fedify-dev/fedify/issues/792
+
+### @fedify/vocab
+
+ -  Explicit ActivityStreams `Link` objects in `icon` and `image` properties
+    are now normalized to `Image` during decoding via the new
+    `normalizeLinkToImage` preprocessor.  The public `Image`-oriented
+    TypeScript API is unchanged.  [[#790], [#792]]
+
+[#790]: https://github.com/fedify-dev/fedify/issues/790
+
+### @fedify/vocab-tools
+
+ -  Property schemas now support a `preprocessors` field that lists
+    module/function pairs.  Generated decoders dynamically import and run
+    these preprocessors for each expanded JSON-LD property value before
+    falling back to the normal range decoder.  [[#792]]
+
 
 Version 2.2.5
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -365,7 +365,7 @@ To be released.
 ### @fedify/vocab-tools
 
  -  Property schemas now support a `preprocessors` field that lists
-    module/function pairs.  Generated decoders dynamically import and run
+    module/function pairs.  Generated decoders statically import and run
     these preprocessors for each expanded JSON-LD property value before
     falling back to the normal range decoder.  [[#792]]
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -352,8 +352,8 @@ To be released.
 ### @fedify/vocab
 
  -  Explicit ActivityStreams `Link` objects in `icon` and `image` properties
-    are now normalized to `Image` during decoding via the new
-    `normalizeLinkToImage` preprocessor.  The public `Image`-oriented
+    are now normalized to `Image` during decoding via the new exported
+    `normalizeLinkToImage()` preprocessor.  The public `Image`-oriented
     TypeScript API is unchanged.  [[#790], [#792]]
 
 [#790]: https://github.com/fedify-dev/fedify/issues/790

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -356,6 +356,10 @@ To be released.
     `normalizeLinkToImage()` preprocessor.  The public `Image`-oriented
     TypeScript API is unchanged.  [[#790], [#792]]
 
+ -  The generated `fromJsonLd()` methods no longer resolve blank node
+    identifiers (`_:b0`) against `options.baseUrl`; blank nodes are left
+    as `null` in the resulting instance's `id` field.  [[#792]]
+
 [#790]: https://github.com/fedify-dev/fedify/issues/790
 
 ### @fedify/vocab-tools
@@ -364,6 +368,14 @@ To be released.
     module/function pairs.  Generated decoders dynamically import and run
     these preprocessors for each expanded JSON-LD property value before
     falling back to the normal range decoder.  [[#792]]
+
+ -  The generated base class now stores the `baseUrl` from `fromJsonLd()`
+    as a protected `_baseUrl` field.  This URL is used to resolve
+    relative URIs when cached embedded property documents are re-parsed
+    lazily by accessors like `getIcon()`, so that callers do not need to
+    pass an explicit `baseUrl`.  The stored URL is defensively copied so
+    that mutation of the caller's original `URL` object does not affect
+    later resolution.  [[#792]]
 
 
 Version 2.2.5

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,5 @@
 .jsr-cache.json
-.jsr-cache-*.json
+.jsr-*-cache.json
 .vitepress/cache/
 .vitepress/dist/
 node_modules/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,5 +1,5 @@
 .jsr-cache.json
-.jsr-*-cache.json
+.jsr-cache-*.json
 .vitepress/cache/
 .vitepress/dist/
 node_modules/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,5 @@
 .jsr-cache.json
+.jsr-cache-*.json
 .jsr-*-cache.json
 .vitepress/cache/
 .vitepress/dist/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -16,7 +16,7 @@ import llmstxt from "vitepress-plugin-llms";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
 const jsrRefPlugins: (Awaited<ReturnType<typeof jsrRef>>)[] = [];
-for (const pkg of ["fedify", "vocab", "vocab-runtime", "webfinger"]) {
+for (const pkg of ["fedify", "vocab", "vocab-runtime", "webfinger", "debugger", "testing"]) {
   const jsrRefPlugin = await jsrRef({
     package: `@fedify/${pkg}`,
     version: process.env.JSR_REF_VERSION ?? "unstable",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,6 +2,7 @@ import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import abbr from "markdown-it-abbr";
 import deflist from "markdown-it-deflist";
 import footnote from "markdown-it-footnote";
+import taskLists from "@hackmd/markdown-it-task-lists";
 import { jsrRef } from "markdown-it-jsr-ref";
 import { readFileSync } from "node:fs";
 import process from "node:process";
@@ -295,6 +296,7 @@ export default withMermaid(defineConfig({
       md.use(abbr);
       md.use(deflist);
       md.use(footnote);
+      md.use(taskLists);
       md.use(groupIconMdPlugin);
       for (const jsrRefPlugin of jsrRefPlugins) {
         md.use(jsrRefPlugin);

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,4 +1,3 @@
-import taskLists from "@hackmd/markdown-it-task-lists";
 import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import abbr from "markdown-it-abbr";
 import deflist from "markdown-it-deflist";
@@ -15,24 +14,15 @@ import {
 import llmstxt from "vitepress-plugin-llms";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
-const jsrRefVersion = process.env.JSR_REF_VERSION ?? "unstable";
-const jsrRefPackages = [
-  ["@fedify/fedify", ".jsr-cache.json"],
-  ["@fedify/vocab", ".jsr-vocab-cache.json"],
-  ["@fedify/vocab-runtime", ".jsr-vocab-runtime-cache.json"],
-  ["@fedify/webfinger", ".jsr-webfinger-cache.json"],
-  ["@fedify/debugger", ".jsr-debugger-cache.json"],
-  ["@fedify/testing", ".jsr-testing-cache.json"],
-] as const;
-const jsrRefPlugins = await Promise.all(
-  jsrRefPackages.map(([packageName, cachePath]) =>
-    jsrRef({
-      package: packageName,
-      version: jsrRefVersion,
-      cachePath,
-    })
-  ),
-);
+const jsrRefPlugins: (Awaited<ReturnType<typeof jsrRef>>)[] = [];
+for (const pkg of ["fedify", "vocab", "vocab-runtime", "webfinger"]) {
+  const jsrRefPlugin = await jsrRef({
+    package: `@fedify/${pkg}`,
+    version: process.env.JSR_REF_VERSION ?? "unstable",
+    cachePath: `.jsr-cache-${pkg}.json`,
+  });
+  jsrRefPlugins.push(jsrRefPlugin);
+}
 
 let extraNav: { text: string; link: string }[] = [];
 if (process.env.EXTRA_NAV_TEXT && process.env.EXTRA_NAV_LINK) {
@@ -112,15 +102,6 @@ const TUTORIAL = {
     },
     { text: "Learning the basics", link: "/tutorial/basics.md" },
     { text: "Creating a microblog", link: "/tutorial/microblog.md" },
-    {
-      text: "Creating an image sharing service",
-      link: "/tutorial/content-sharing.md",
-    },
-    { text: "Building a federated blog", link: "/tutorial/astro-blog.md" },
-    {
-      text: "Building a threadiverse community",
-      link: "/tutorial/threadiverse.md",
-    },
   ],
   activeMatch: "/tutorial",
 };
@@ -134,7 +115,6 @@ const MANUAL = {
     { text: "Vocabulary", link: "/manual/vocab.md" },
     { text: "Actor dispatcher", link: "/manual/actor.md" },
     { text: "Inbox listeners", link: "/manual/inbox.md" },
-    { text: "Outbox listeners", link: "/manual/outbox.md" },
     { text: "Sending activities", link: "/manual/send.md" },
     { text: "Collections", link: "/manual/collections.md" },
     { text: "Object dispatcher", link: "/manual/object.md" },
@@ -145,16 +125,13 @@ const MANUAL = {
     { text: "Pragmatics", link: "/manual/pragmatics.md" },
     { text: "Key–value store", link: "/manual/kv.md" },
     { text: "Message queue", link: "/manual/mq.md" },
-    { text: "Circuit breaker", link: "/manual/circuit-breaker.md" },
     { text: "Integration", link: "/manual/integration.md" },
-    { text: "Migration", link: "/manual/migrate.md" },
     { text: "Relay", link: "/manual/relay.md" },
     { text: "Testing", link: "/manual/test.md" },
     { text: "Debugging", link: "/manual/debug.md" },
     { text: "Linting", link: "/manual/lint.md" },
     { text: "Logging", link: "/manual/log.md" },
     { text: "OpenTelemetry", link: "/manual/opentelemetry.md" },
-    { text: "Benchmarking", link: "/manual/benchmarking.md" },
     { text: "Deployment", link: "/manual/deploy.md" },
   ],
   activeMatch: "/manual",
@@ -297,10 +274,6 @@ export default withMermaid(defineConfig({
             target: ScriptTarget.ESNext,
             experimentalDecorators: true, // For @fedify/nestjs
             emitDecoratorMetadata: true, // For @fedify/nestjs
-            // Silences TS5101 about the `baseUrl` injected by @typescript/vfs
-            // when Twoslash spins up its virtual TS environment; the option
-            // is deprecated in TypeScript 6.0 and removed in 7.0.
-            ignoreDeprecations: "6.0",
             lib: ["dom", "dom.iterable", "esnext"],
             types: [
               "dom",
@@ -321,7 +294,6 @@ export default withMermaid(defineConfig({
       md.use(abbr);
       md.use(deflist);
       md.use(footnote);
-      md.use(taskLists);
       md.use(groupIconMdPlugin);
       for (const jsrRefPlugin of jsrRefPlugins) {
         md.use(jsrRefPlugin);
@@ -336,20 +308,14 @@ export default withMermaid(defineConfig({
     plugins: [
       groupIconVitePlugin(),
       llmstxt({
-        ignoreFilesPerOutput: {
-          llmsTxt: [
-            "changelog.md",
-            "contribute.md",
-            "README.md",
-            "sponsors.md",
-          ],
-          llmsFullTxt: [
-            "changelog.md",
-            "contribute.md",
-            "README.md",
-            "sponsors.md",
-          ],
-        },
+        ignoreFiles: [
+          "changelog.md",
+          "contribute.md",
+          "README.md",
+          "security.md",
+          "sponsors.md",
+          "tutorial.md",
+        ],
       }),
     ],
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,8 +1,8 @@
+import taskLists from "@hackmd/markdown-it-task-lists";
 import { transformerTwoslash } from "@shikijs/vitepress-twoslash";
 import abbr from "markdown-it-abbr";
 import deflist from "markdown-it-deflist";
 import footnote from "markdown-it-footnote";
-import taskLists from "@hackmd/markdown-it-task-lists";
 import { jsrRef } from "markdown-it-jsr-ref";
 import { readFileSync } from "node:fs";
 import process from "node:process";
@@ -15,15 +15,24 @@ import {
 import llmstxt from "vitepress-plugin-llms";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
-const jsrRefPlugins: (Awaited<ReturnType<typeof jsrRef>>)[] = [];
-for (const pkg of ["fedify", "vocab", "vocab-runtime", "webfinger", "debugger", "testing"]) {
-  const jsrRefPlugin = await jsrRef({
-    package: `@fedify/${pkg}`,
-    version: process.env.JSR_REF_VERSION ?? "unstable",
-    cachePath: `.jsr-cache-${pkg}.json`,
-  });
-  jsrRefPlugins.push(jsrRefPlugin);
-}
+const jsrRefVersion = process.env.JSR_REF_VERSION ?? "unstable";
+const jsrRefPackages = [
+  ["@fedify/fedify", ".jsr-cache.json"],
+  ["@fedify/vocab", ".jsr-vocab-cache.json"],
+  ["@fedify/vocab-runtime", ".jsr-vocab-runtime-cache.json"],
+  ["@fedify/webfinger", ".jsr-webfinger-cache.json"],
+  ["@fedify/debugger", ".jsr-debugger-cache.json"],
+  ["@fedify/testing", ".jsr-testing-cache.json"],
+] as const;
+const jsrRefPlugins = await Promise.all(
+  jsrRefPackages.map(([packageName, cachePath]) =>
+    jsrRef({
+      package: packageName,
+      version: jsrRefVersion,
+      cachePath,
+    })
+  ),
+);
 
 let extraNav: { text: string; link: string }[] = [];
 if (process.env.EXTRA_NAV_TEXT && process.env.EXTRA_NAV_LINK) {
@@ -103,6 +112,15 @@ const TUTORIAL = {
     },
     { text: "Learning the basics", link: "/tutorial/basics.md" },
     { text: "Creating a microblog", link: "/tutorial/microblog.md" },
+    {
+      text: "Creating an image sharing service",
+      link: "/tutorial/content-sharing.md",
+    },
+    { text: "Building a federated blog", link: "/tutorial/astro-blog.md" },
+    {
+      text: "Building a threadiverse community",
+      link: "/tutorial/threadiverse.md",
+    },
   ],
   activeMatch: "/tutorial",
 };
@@ -116,6 +134,7 @@ const MANUAL = {
     { text: "Vocabulary", link: "/manual/vocab.md" },
     { text: "Actor dispatcher", link: "/manual/actor.md" },
     { text: "Inbox listeners", link: "/manual/inbox.md" },
+    { text: "Outbox listeners", link: "/manual/outbox.md" },
     { text: "Sending activities", link: "/manual/send.md" },
     { text: "Collections", link: "/manual/collections.md" },
     { text: "Object dispatcher", link: "/manual/object.md" },
@@ -126,13 +145,16 @@ const MANUAL = {
     { text: "Pragmatics", link: "/manual/pragmatics.md" },
     { text: "Key–value store", link: "/manual/kv.md" },
     { text: "Message queue", link: "/manual/mq.md" },
+    { text: "Circuit breaker", link: "/manual/circuit-breaker.md" },
     { text: "Integration", link: "/manual/integration.md" },
+    { text: "Migration", link: "/manual/migrate.md" },
     { text: "Relay", link: "/manual/relay.md" },
     { text: "Testing", link: "/manual/test.md" },
     { text: "Debugging", link: "/manual/debug.md" },
     { text: "Linting", link: "/manual/lint.md" },
     { text: "Logging", link: "/manual/log.md" },
     { text: "OpenTelemetry", link: "/manual/opentelemetry.md" },
+    { text: "Benchmarking", link: "/manual/benchmarking.md" },
     { text: "Deployment", link: "/manual/deploy.md" },
   ],
   activeMatch: "/manual",
@@ -270,12 +292,15 @@ export default withMermaid(defineConfig({
       transformerTwoslash({
         twoslashOptions: {
           compilerOptions: {
-            ignoreDeprecations: "6.0",
             moduleResolution: ModuleResolutionKind.Bundler,
             module: ModuleKind.ESNext,
             target: ScriptTarget.ESNext,
             experimentalDecorators: true, // For @fedify/nestjs
             emitDecoratorMetadata: true, // For @fedify/nestjs
+            // Silences TS5101 about the `baseUrl` injected by @typescript/vfs
+            // when Twoslash spins up its virtual TS environment; the option
+            // is deprecated in TypeScript 6.0 and removed in 7.0.
+            ignoreDeprecations: "6.0",
             lib: ["dom", "dom.iterable", "esnext"],
             types: [
               "dom",
@@ -311,14 +336,20 @@ export default withMermaid(defineConfig({
     plugins: [
       groupIconVitePlugin(),
       llmstxt({
-        ignoreFiles: [
-          "changelog.md",
-          "contribute.md",
-          "README.md",
-          "security.md",
-          "sponsors.md",
-          "tutorial.md",
-        ],
+        ignoreFilesPerOutput: {
+          llmsTxt: [
+            "changelog.md",
+            "contribute.md",
+            "README.md",
+            "sponsors.md",
+          ],
+          llmsFullTxt: [
+            "changelog.md",
+            "contribute.md",
+            "README.md",
+            "sponsors.md",
+          ],
+        },
       }),
     ],
   },

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -269,6 +269,7 @@ export default withMermaid(defineConfig({
       transformerTwoslash({
         twoslashOptions: {
           compilerOptions: {
+            ignoreDeprecations: "6.0",
             moduleResolution: ModuleResolutionKind.Bundler,
             module: ModuleKind.ESNext,
             target: ScriptTarget.ESNext,

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -35,6 +35,12 @@ import {
   writeSeparator,
 } from "./lookup.ts";
 
+const testRuntime = "Bun" in globalThis ? "bun" : "node";
+
+function getTestOutputDir(name: string): string {
+  return `./test_output_${testRuntime}_${name}`;
+}
+
 async function parseWithConfig<TValue, TState>(
   parser: Parser<"sync", TValue, TState>,
   args: readonly string[],
@@ -54,7 +60,7 @@ async function parseWithConfig<TValue, TState>(
 }
 
 test("writeObjectToStream - writes Note object with default options", async () => {
-  const testDir = "./test_output_note";
+  const testDir = getTestOutputDir("note");
   const testFile = `${testDir}/note.txt`;
 
   await mkdir(testDir, { recursive: true });
@@ -78,7 +84,7 @@ test("writeObjectToStream - writes Note object with default options", async () =
 });
 
 test("writeObjectToStream - writes Activity object in raw JSON-LD format", async () => {
-  const testDir = "./test_output_activity";
+  const testDir = getTestOutputDir("activity");
   const testFile = `${testDir}/raw.json`;
 
   await mkdir(testDir, { recursive: true });
@@ -102,7 +108,7 @@ test("writeObjectToStream - writes Activity object in raw JSON-LD format", async
 });
 
 test("writeObjectToStream - writes object in compact JSON-LD format", async () => {
-  const testDir = "./test_output_compact";
+  const testDir = getTestOutputDir("compact");
   const testFile = `${testDir}/compact.json`;
 
   await mkdir(testDir, { recursive: true });
@@ -125,7 +131,7 @@ test("writeObjectToStream - writes object in compact JSON-LD format", async () =
 });
 
 test("writeObjectToStream - writes object in expanded JSON-LD format", async () => {
-  const testDir = "./test_output_expand";
+  const testDir = getTestOutputDir("expand");
   const testFile = `${testDir}/expand.json`;
 
   await mkdir(testDir, { recursive: true });
@@ -147,7 +153,7 @@ test("writeObjectToStream - writes object in expanded JSON-LD format", async () 
 });
 
 test("writeObjectToStream - supports reusing an output stream", async () => {
-  const testDir = "./test_output_reused_stream";
+  const testDir = getTestOutputDir("reused_stream");
   const testFile = `${testDir}/notes.txt`;
 
   await mkdir(testDir, { recursive: true });
@@ -181,7 +187,7 @@ test("writeObjectToStream - supports reusing an output stream", async () => {
 });
 
 test("writeSeparator - writes to provided output stream", async () => {
-  const testDir = "./test_output_separator";
+  const testDir = getTestOutputDir("separator");
   const testFile = `${testDir}/separator.txt`;
   await mkdir(testDir, { recursive: true });
 
@@ -244,7 +250,7 @@ test("writeObjectToStream - writes to stdout when no output file specified", asy
 });
 
 test("writeObjectToStream - handles empty content properly", async () => {
-  const testDir = "./test_output_empty";
+  const testDir = getTestOutputDir("empty");
   const testFile = `${testDir}/empty.txt`;
 
   await mkdir(testDir, { recursive: true });
@@ -1191,7 +1197,7 @@ async function withRecursiveLookupServer<T>(
 }
 
 test("runLookup - rejects recursive private targets by default", async () => {
-  const testDir = "./test_output_runlookup_recurse_private_default";
+  const testDir = getTestOutputDir("runlookup_recurse_private_default");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1226,7 +1232,7 @@ test("runLookup - rejects recursive private targets by default", async () => {
 });
 
 test("runLookup - allows recursive private targets with allowPrivateAddress", async () => {
-  const testDir = "./test_output_runlookup_recurse_private_allowed";
+  const testDir = getTestOutputDir("runlookup_recurse_private_allowed");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1258,7 +1264,7 @@ test("runLookup - allows recursive private targets with allowPrivateAddress", as
 });
 
 test("runLookup - keeps recursive private contexts blocked", async () => {
-  const testDir = "./test_output_runlookup_recurse_private_context";
+  const testDir = getTestOutputDir("runlookup_recurse_private_context");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1293,7 +1299,7 @@ test("runLookup - keeps recursive private contexts blocked", async () => {
 });
 
 test("runLookup - reverses output order in default multi-input mode", async () => {
-  const testDir = "./test_output_runlookup_default_reverse";
+  const testDir = getTestOutputDir("runlookup_default_reverse");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1349,7 +1355,7 @@ test("runLookup - reverses output order in default multi-input mode", async () =
 });
 
 test("runLookup - reverses output order in recurse mode", async () => {
-  const testDir = "./test_output_runlookup_recurse_reverse";
+  const testDir = getTestOutputDir("runlookup_recurse_reverse");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1412,7 +1418,7 @@ test("runLookup - reverses output order in recurse mode", async () => {
 });
 
 test("runLookup - reverses output order in traverse mode", async () => {
-  const testDir = "./test_output_runlookup_traverse_reverse";
+  const testDir = getTestOutputDir("runlookup_traverse_reverse");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1455,7 +1461,9 @@ test("runLookup - reverses output order in traverse mode", async () => {
 });
 
 test("runLookup - emits reversed partial items on traverse reverse failure", async () => {
-  const testDir = "./test_output_runlookup_traverse_reverse_partial_failure";
+  const testDir = getTestOutputDir(
+    "runlookup_traverse_reverse_partial_failure",
+  );
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
@@ -1503,7 +1511,7 @@ test("runLookup - emits reversed partial items on traverse reverse failure", asy
 });
 
 test("runLookup - writes separators between adjacent traversed items", async () => {
-  const testDir = "./test_output_runlookup_traverse_separator";
+  const testDir = getTestOutputDir("runlookup_traverse_separator");
   const testFile = `${testDir}/out.jsonl`;
   const separator = "<SEP>";
   await mkdir(testDir, { recursive: true });
@@ -1566,7 +1574,7 @@ test("runLookup - writes separators between adjacent traversed items", async () 
 test(
   "runLookup - writes separators between adjacent traversed items in reverse mode",
   async () => {
-    const testDir = "./test_output_runlookup_traverse_separator_reverse";
+    const testDir = getTestOutputDir("runlookup_traverse_separator_reverse");
     const testFile = `${testDir}/out.jsonl`;
     const separator = "<SEP>";
     await mkdir(testDir, { recursive: true });
@@ -1629,7 +1637,7 @@ test(
 );
 
 test("runLookup - emits root object on recurse reverse failure", async () => {
-  const testDir = "./test_output_runlookup_recurse_reverse_partial_failure";
+  const testDir = getTestOutputDir("runlookup_recurse_reverse_partial_failure");
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {

--- a/packages/fedify/src/federation/handler.ts
+++ b/packages/fedify/src/federation/handler.ts
@@ -132,7 +132,7 @@ function isInvalidJsonLdError(error: unknown): error is Error {
 
 function isValidationTypeError(error: unknown): error is TypeError {
   return error instanceof TypeError &&
-    (/^(Invalid JSON-LD:|Invalid type:|Unexpected type:)/
+    (/^(Invalid JSON-LD:|Invalid type:|Unexpected type:|Invalid @id:)/
       .test(error.message) ||
       isInvalidUrlTypeError(error));
 }

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -410,7 +410,7 @@ function isPermanentInboxParseError(error: unknown): error is Error {
       (error.name === "jsonld.SyntaxError" &&
         !isRemoteContextLoadingFailure(error)))) ||
     (error instanceof TypeError &&
-      (/^(Invalid JSON-LD:|Invalid type:|Unexpected type:)/
+      (/^(Invalid JSON-LD:|Invalid type:|Unexpected type:|Invalid @id:)/
         .test(error.message) ||
         isInvalidUrlTypeError(error)));
 }

--- a/packages/vocab-runtime/src/mod.ts
+++ b/packages/vocab-runtime/src/mod.ts
@@ -45,6 +45,11 @@ export {
   logRequest,
 } from "./request.ts";
 export {
+  type Json,
+  type PropertyPreprocessor,
+  type PropertyPreprocessorContext,
+} from "./preprocessor.ts";
+export {
   expandIPv6Address,
   isValidPublicIPv4Address,
   isValidPublicIPv6Address,

--- a/packages/vocab-runtime/src/preprocessor.ts
+++ b/packages/vocab-runtime/src/preprocessor.ts
@@ -3,6 +3,7 @@ import type { TracerProvider } from "@opentelemetry/api";
 
 /**
  * JSON value shape passed to property preprocessors.
+ * @since 2.3.0
  */
 export type Json =
   | string
@@ -14,6 +15,7 @@ export type Json =
 
 /**
  * Runtime context provided to property preprocessors.
+ * @since 2.3.0
  */
 export interface PropertyPreprocessorContext {
   /** Loader for remote JSON-LD documents. */
@@ -33,6 +35,7 @@ export interface PropertyPreprocessorContext {
  * object when the value is handled, `undefined` when the value should
  * fall through to the normal range decoder, or an `Error` when the value
  * is recognized but cannot be converted.
+ * @since 2.3.0
  */
 export type PropertyPreprocessor<T = unknown> = (
   value: Json,

--- a/packages/vocab-runtime/src/preprocessor.ts
+++ b/packages/vocab-runtime/src/preprocessor.ts
@@ -1,0 +1,22 @@
+import type { DocumentLoader } from "./docloader.ts";
+import type { TracerProvider } from "@opentelemetry/api";
+
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | readonly Json[]
+  | { readonly [key: string]: Json };
+
+export interface PropertyPreprocessorContext {
+  documentLoader?: DocumentLoader;
+  contextLoader?: DocumentLoader;
+  tracerProvider?: TracerProvider;
+  baseUrl?: URL;
+}
+
+export type PropertyPreprocessor<T = unknown> = (
+  value: Json,
+  context: PropertyPreprocessorContext,
+) => T | undefined | Error | Promise<T | undefined | Error>;

--- a/packages/vocab-runtime/src/preprocessor.ts
+++ b/packages/vocab-runtime/src/preprocessor.ts
@@ -1,6 +1,9 @@
 import type { DocumentLoader } from "./docloader.ts";
 import type { TracerProvider } from "@opentelemetry/api";
 
+/**
+ * JSON value shape passed to property preprocessors.
+ */
 export type Json =
   | string
   | number
@@ -9,13 +12,28 @@ export type Json =
   | readonly Json[]
   | { readonly [key: string]: Json };
 
+/**
+ * Runtime context provided to property preprocessors.
+ */
 export interface PropertyPreprocessorContext {
+  /** Loader for remote JSON-LD documents. */
   documentLoader?: DocumentLoader;
+  /** Loader for remote JSON-LD contexts. */
   contextLoader?: DocumentLoader;
+  /** OpenTelemetry tracer provider for instrumentation. */
   tracerProvider?: TracerProvider;
+  /** Base URL for resolving relative references. */
   baseUrl?: URL;
 }
 
+/**
+ * Function signature for schema-configured property preprocessors.
+ *
+ * Receives an expanded JSON-LD property value and returns a vocabulary
+ * object when the value is handled, `undefined` when the value should
+ * fall through to the normal range decoder, or an `Error` when the value
+ * is recognized but cannot be converted.
+ */
 export type PropertyPreprocessor<T = unknown> = (
   value: Json,
   context: PropertyPreprocessorContext,

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -28,6 +28,8 @@ import {
 } from \\"@fedify/vocab-runtime/temporal\\";
 
 
+import * as _ppM0 from \\"./preprocessors.ts\\";
+
 /** Describes an object of any kind. The Object type serves as the base type for
  * most of the other kinds of objects defined in the Activity Vocabulary,
  * including other Core types such as {@link Activity},
@@ -2334,7 +2336,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attachment\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attachment_fromJsonLd(obj, options);
+              v = await this.#attachment_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -2588,7 +2594,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"attributedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#attribution_fromJsonLd(doc, options);
+            v = await this.#attribution_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -2684,7 +2694,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attributedTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attribution_fromJsonLd(obj, options);
+              v = await this.#attribution_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -2901,7 +2915,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"audience\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#audience_fromJsonLd(doc, options);
+            v = await this.#audience_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -2996,7 +3014,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"audience\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#audience_fromJsonLd(obj, options);
+              v = await this.#audience_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3257,7 +3279,11 @@ get contents(): ((string | LanguageString))[] {
               \\"context\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#context_fromJsonLd(obj, options);
+              v = await this.#context_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3525,7 +3551,11 @@ get names(): ((string | LanguageString))[] {
               \\"generator\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#generator_fromJsonLd(obj, options);
+              v = await this.#generator_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3670,7 +3700,6 @@ get names(): ((string | LanguageString))[] {
         for (const _pp_obj of _expanded) {
       
           {
-            const _ppM0 = await import(\\"./preprocessors.ts\\");
             const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
               documentLoader,
               contextLoader,
@@ -3763,7 +3792,11 @@ get names(): ((string | LanguageString))[] {
             \\"icon\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#icon_fromJsonLd(doc, options);
+            v = await this.#icon_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -3859,7 +3892,11 @@ get names(): ((string | LanguageString))[] {
               \\"icon\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#icon_fromJsonLd(obj, options);
+              v = await this.#icon_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4004,7 +4041,6 @@ get names(): ((string | LanguageString))[] {
         for (const _pp_obj of _expanded) {
       
           {
-            const _ppM0 = await import(\\"./preprocessors.ts\\");
             const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
               documentLoader,
               contextLoader,
@@ -4097,7 +4133,11 @@ get names(): ((string | LanguageString))[] {
             \\"image\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#image_fromJsonLd(doc, options);
+            v = await this.#image_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4193,7 +4233,11 @@ get names(): ((string | LanguageString))[] {
               \\"image\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#image_fromJsonLd(obj, options);
+              v = await this.#image_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4419,7 +4463,11 @@ get names(): ((string | LanguageString))[] {
             \\"inReplyTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyTarget_fromJsonLd(doc, options);
+            v = await this.#replyTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4514,7 +4562,11 @@ get names(): ((string | LanguageString))[] {
               \\"inReplyTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#replyTarget_fromJsonLd(obj, options);
+              v = await this.#replyTarget_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4740,7 +4792,11 @@ get names(): ((string | LanguageString))[] {
             \\"location\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#location_fromJsonLd(doc, options);
+            v = await this.#location_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4835,7 +4891,11 @@ get names(): ((string | LanguageString))[] {
               \\"location\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#location_fromJsonLd(obj, options);
+              v = await this.#location_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -5060,7 +5120,11 @@ get names(): ((string | LanguageString))[] {
             \\"preview\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#preview_fromJsonLd(doc, options);
+            v = await this.#preview_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5154,7 +5218,11 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -5384,7 +5452,11 @@ get names(): ((string | LanguageString))[] {
             \\"replies\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replies_fromJsonLd(doc, options);
+            v = await this.#replies_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5606,7 +5678,11 @@ get names(): ((string | LanguageString))[] {
             \\"shares\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#shares_fromJsonLd(doc, options);
+            v = await this.#shares_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5828,7 +5904,11 @@ get names(): ((string | LanguageString))[] {
             \\"likes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likes_fromJsonLd(doc, options);
+            v = await this.#likes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6044,7 +6124,11 @@ get names(): ((string | LanguageString))[] {
             \\"emojiReactions\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#emojiReactions_fromJsonLd(doc, options);
+            v = await this.#emojiReactions_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6312,7 +6396,11 @@ get summaries(): ((string | LanguageString))[] {
               \\"tag\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#tag_fromJsonLd(obj, options);
+              v = await this.#tag_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -6563,7 +6651,11 @@ get urls(): ((URL | Link))[] {
             \\"to\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#to_fromJsonLd(doc, options);
+            v = await this.#to_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6658,7 +6750,11 @@ get urls(): ((URL | Link))[] {
               \\"to\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#to_fromJsonLd(obj, options);
+              v = await this.#to_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -6875,7 +6971,11 @@ get urls(): ((URL | Link))[] {
             \\"bto\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bto_fromJsonLd(doc, options);
+            v = await this.#bto_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6970,7 +7070,11 @@ get urls(): ((URL | Link))[] {
               \\"bto\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bto_fromJsonLd(obj, options);
+              v = await this.#bto_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7187,7 +7291,11 @@ get urls(): ((URL | Link))[] {
             \\"cc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#cc_fromJsonLd(doc, options);
+            v = await this.#cc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7282,7 +7390,11 @@ get urls(): ((URL | Link))[] {
               \\"cc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#cc_fromJsonLd(obj, options);
+              v = await this.#cc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7499,7 +7611,11 @@ get urls(): ((URL | Link))[] {
             \\"bcc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bcc_fromJsonLd(doc, options);
+            v = await this.#bcc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7594,7 +7710,11 @@ get urls(): ((URL | Link))[] {
               \\"bcc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bcc_fromJsonLd(obj, options);
+              v = await this.#bcc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7874,7 +7994,11 @@ get urls(): ((URL | Link))[] {
             \\"proof\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#proof_fromJsonLd(doc, options);
+            v = await this.#proof_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7968,7 +8092,11 @@ get urls(): ((URL | Link))[] {
               \\"proof\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#proof_fromJsonLd(obj, options);
+              v = await this.#proof_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -8224,7 +8352,11 @@ get urls(): ((URL | Link))[] {
             \\"likeAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+            v = await this.#likeAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -8440,7 +8572,11 @@ get urls(): ((URL | Link))[] {
             \\"replyAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+            v = await this.#replyAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -8656,7 +8792,11 @@ get urls(): ((URL | Link))[] {
             \\"announceAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+            v = await this.#announceAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -10602,7 +10742,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10783,12 +10923,11 @@ get urls(): ((URL | Link))[] {
         let _handled: Image | undefined;
       
         if (_handled === undefined) {
-          const _ppM0 = await import(\\"./preprocessors.ts\\");
           const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10814,7 +10953,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10839,12 +10978,11 @@ get urls(): ((URL | Link))[] {
         let _handled: Image | undefined;
       
         if (_handled === undefined) {
-          const _ppM0 = await import(\\"./preprocessors.ts\\");
           const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10870,7 +11008,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11054,7 +11192,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11087,7 +11225,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11120,7 +11258,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11153,7 +11291,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11340,7 +11478,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11373,7 +11511,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11406,7 +11544,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11439,7 +11577,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11514,7 +11652,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11547,7 +11685,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11568,7 +11706,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11600,9 +11738,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11634,7 +11772,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11667,7 +11805,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11700,7 +11838,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13315,7 +13453,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -13554,7 +13696,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -13927,7 +14073,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -13986,7 +14132,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -14932,7 +15078,11 @@ instruments?: (Object | URL)[];}
             \\"actor\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#actor_fromJsonLd(doc, options);
+            v = await this.#actor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15028,7 +15178,11 @@ instruments?: (Object | URL)[];}
               \\"actor\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#actor_fromJsonLd(obj, options);
+              v = await this.#actor_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15246,7 +15400,11 @@ instruments?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15342,7 +15500,11 @@ instruments?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15563,7 +15725,11 @@ instruments?: (Object | URL)[];}
             \\"target\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#target_fromJsonLd(doc, options);
+            v = await this.#target_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15662,7 +15828,11 @@ instruments?: (Object | URL)[];}
               \\"target\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#target_fromJsonLd(obj, options);
+              v = await this.#target_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15880,7 +16050,11 @@ instruments?: (Object | URL)[];}
             \\"result\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#result_fromJsonLd(doc, options);
+            v = await this.#result_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15976,7 +16150,11 @@ instruments?: (Object | URL)[];}
               \\"result\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#result_fromJsonLd(obj, options);
+              v = await this.#result_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16195,7 +16373,11 @@ instruments?: (Object | URL)[];}
             \\"origin\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#origin_fromJsonLd(doc, options);
+            v = await this.#origin_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -16292,7 +16474,11 @@ instruments?: (Object | URL)[];}
               \\"origin\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#origin_fromJsonLd(obj, options);
+              v = await this.#origin_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16509,7 +16695,11 @@ instruments?: (Object | URL)[];}
             \\"instrument\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#instrument_fromJsonLd(doc, options);
+            v = await this.#instrument_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -16604,7 +16794,11 @@ instruments?: (Object | URL)[];}
               \\"instrument\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#instrument_fromJsonLd(obj, options);
+              v = await this.#instrument_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -17125,7 +17319,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17158,7 +17352,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17191,7 +17385,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17224,7 +17418,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17257,7 +17451,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19316,7 +19510,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -19531,7 +19729,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -19859,7 +20061,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -19892,7 +20094,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20882,7 +21084,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -20903,7 +21105,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -20924,7 +21126,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -20945,7 +21147,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21641,9 +21843,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21674,9 +21876,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22136,7 +22338,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -22351,7 +22557,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -22679,7 +22889,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22712,7 +22922,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23488,7 +23698,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -23703,7 +23917,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -24031,7 +24249,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24064,7 +24282,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24839,7 +25057,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -25054,7 +25276,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -25382,7 +25608,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25415,7 +25641,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26273,9 +26499,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27459,7 +27685,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28085,7 +28311,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
             \\"owner\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#owner_fromJsonLd(doc, options);
+            v = await this.#owner_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -28956,7 +29186,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
             \\"controller\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#controller_fromJsonLd(doc, options);
+            v = await this.#controller_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -30136,9 +30370,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30158,7 +30392,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30179,7 +30413,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30200,7 +30434,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31002,7 +31236,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31023,7 +31257,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -33389,7 +33623,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -33482,7 +33720,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -33701,7 +33943,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -33798,7 +34044,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -34054,7 +34304,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34287,7 +34541,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34506,7 +34764,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34728,7 +34990,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34948,7 +35214,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35166,7 +35436,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35384,7 +35658,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35600,7 +35878,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -35926,7 +36208,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36180,7 +36466,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36277,7 +36567,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -36496,7 +36790,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36593,7 +36891,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -37701,7 +38003,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37734,7 +38036,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37867,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -37900,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -37933,7 +38235,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -37966,7 +38268,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -37999,7 +38301,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38032,7 +38334,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38053,7 +38355,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38264,7 +38566,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39868,7 +40170,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -40107,7 +40413,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -40480,7 +40790,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40539,7 +40849,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -42928,7 +43238,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"current\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#current_fromJsonLd(doc, options);
+            v = await this.#current_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43144,7 +43458,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"first\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#first_fromJsonLd(doc, options);
+            v = await this.#first_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43360,7 +43678,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"last\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#last_fromJsonLd(doc, options);
+            v = await this.#last_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43586,7 +43908,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"items\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -43802,7 +44128,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likesOf_fromJsonLd(doc, options);
+            v = await this.#likesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44017,7 +44347,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"sharesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#sharesOf_fromJsonLd(doc, options);
+            v = await this.#sharesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44232,7 +44566,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"repliesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#repliesOf_fromJsonLd(doc, options);
+            v = await this.#repliesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44447,7 +44785,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"inboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inboxOf_fromJsonLd(doc, options);
+            v = await this.#inboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44662,7 +45004,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"outboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outboxOf_fromJsonLd(doc, options);
+            v = await this.#outboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44877,7 +45223,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followersOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followersOf_fromJsonLd(doc, options);
+            v = await this.#followersOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45092,7 +45442,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followingOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followingOf_fromJsonLd(doc, options);
+            v = await this.#followingOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45307,7 +45661,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likedOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likedOf_fromJsonLd(doc, options);
+            v = await this.#likedOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -46053,7 +46411,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46086,7 +46444,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46119,7 +46477,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46195,7 +46553,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46228,7 +46586,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46261,7 +46619,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46294,7 +46652,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46327,7 +46685,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46360,7 +46718,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46393,7 +46751,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46426,7 +46784,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47106,7 +47464,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"partOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#partOf_fromJsonLd(doc, options);
+            v = await this.#partOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47320,7 +47682,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"next\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#next_fromJsonLd(doc, options);
+            v = await this.#next_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47535,7 +47901,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"prev\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#prev_fromJsonLd(doc, options);
+            v = await this.#prev_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47902,7 +48272,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -47935,7 +48305,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -47968,7 +48338,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -49847,9 +50217,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -49880,9 +50250,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -49913,9 +50283,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -49946,9 +50316,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -49979,9 +50349,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50012,9 +50382,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -52414,7 +52784,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -52507,7 +52881,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -52726,7 +53104,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -52823,7 +53205,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -53079,7 +53465,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53312,7 +53702,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53531,7 +53925,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53753,7 +54151,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53973,7 +54375,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54191,7 +54597,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54409,7 +54819,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54625,7 +55039,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -54951,7 +55369,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55205,7 +55627,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55302,7 +55728,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -55521,7 +55951,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55618,7 +56052,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -56726,7 +57164,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56759,7 +57197,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -56892,7 +57330,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -56925,7 +57363,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -56958,7 +57396,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -56991,7 +57429,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57024,7 +57462,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57057,7 +57495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57078,7 +57516,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57289,7 +57727,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -58626,7 +59064,11 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -59133,9 +59575,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -63174,7 +63616,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -63413,7 +63859,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -63786,7 +64236,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -63845,7 +64295,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64287,7 +64737,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -65024,7 +65478,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -66696,7 +67154,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -66789,7 +67251,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -67008,7 +67474,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67105,7 +67575,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -67361,7 +67835,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67594,7 +68072,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67813,7 +68295,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68035,7 +68521,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68255,7 +68745,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68473,7 +68967,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68691,7 +69189,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68907,7 +69409,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -69233,7 +69739,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69487,7 +69997,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69584,7 +70098,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -69803,7 +70321,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69900,7 +70422,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -71008,7 +71534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71041,7 +71567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71174,7 +71700,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71207,7 +71733,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71240,7 +71766,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71273,7 +71799,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71306,7 +71832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71339,7 +71865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71360,7 +71886,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71571,7 +72097,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -73674,7 +74200,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -73767,7 +74297,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -73986,7 +74520,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74083,7 +74621,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -74339,7 +74881,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74572,7 +75118,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74791,7 +75341,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75013,7 +75567,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75233,7 +75791,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75451,7 +76013,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75669,7 +76235,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75885,7 +76455,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -76211,7 +76785,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76465,7 +77043,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76562,7 +77144,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -76781,7 +77367,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76878,7 +77468,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -77986,7 +78580,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78019,7 +78613,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78152,7 +78746,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78185,7 +78779,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78218,7 +78812,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78251,7 +78845,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78284,7 +78878,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78317,7 +78911,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78338,7 +78932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78549,7 +79143,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80461,7 +81055,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"describes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#describes_fromJsonLd(doc, options);
+            v = await this.#describes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -80754,7 +81352,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -81347,7 +81945,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"oneOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+              v = await this.#exclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -81566,7 +82168,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"anyOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+              v = await this.#inclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -81814,7 +82420,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -82053,7 +82663,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -82409,7 +83023,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82442,7 +83056,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82524,7 +83138,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82583,7 +83197,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83936,7 +84550,11 @@ relationships?: (Object | URL)[];}
             \\"subject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#subject_fromJsonLd(doc, options);
+            v = await this.#subject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84151,7 +84769,11 @@ relationships?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84245,7 +84867,11 @@ relationships?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -84463,7 +85089,11 @@ relationships?: (Object | URL)[];}
             \\"relationship\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#relationship_fromJsonLd(doc, options);
+            v = await this.#relationship_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84559,7 +85189,11 @@ relationships?: (Object | URL)[];}
               \\"relationship\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#relationship_fromJsonLd(obj, options);
+              v = await this.#relationship_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -84923,7 +85557,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -84956,7 +85590,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -84989,7 +85623,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86653,7 +87287,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -86746,7 +87384,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -86965,7 +87607,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87062,7 +87708,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -87318,7 +87968,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87551,7 +88205,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87770,7 +88428,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87992,7 +88654,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88212,7 +88878,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88430,7 +89100,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88648,7 +89322,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88864,7 +89542,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -89190,7 +89872,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89444,7 +90130,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89541,7 +90231,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -89760,7 +90454,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89857,7 +90555,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -90965,7 +91667,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -90998,7 +91700,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91131,7 +91833,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91164,7 +91866,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91197,7 +91899,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91230,7 +91932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91263,7 +91965,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91296,7 +91998,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91317,7 +92019,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91528,7 +92230,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10891,6 +10891,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -10938,6 +10939,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -10991,6 +10993,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11048,6 +11051,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11137,6 +11141,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11202,6 +11207,7 @@ get urls(): ((URL | Link))[] {
       
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11257,6 +11263,7 @@ get urls(): ((URL | Link))[] {
       
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11290,6 +11297,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11333,6 +11341,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11376,6 +11385,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11441,6 +11451,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11474,6 +11485,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11507,6 +11519,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11540,6 +11553,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11619,6 +11633,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11727,6 +11742,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11760,6 +11776,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11793,6 +11810,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11826,6 +11844,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11934,6 +11953,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -12021,6 +12041,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -12054,6 +12075,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -12087,6 +12109,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -14342,6 +14365,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -14401,6 +14425,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17622,6 +17647,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17675,6 +17701,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17708,6 +17735,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17741,6 +17769,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17774,6 +17803,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17807,6 +17837,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -20457,6 +20488,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -20490,6 +20522,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -23325,6 +23358,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -23358,6 +23392,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -24705,6 +24740,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -24738,6 +24774,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -26084,6 +26121,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -26117,6 +26155,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -28187,6 +28226,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -29155,6 +29195,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -30054,6 +30095,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38683,6 +38725,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38716,6 +38759,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38767,6 +38811,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38808,6 +38853,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38849,6 +38895,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38882,6 +38929,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38915,6 +38963,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38948,6 +38997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38981,6 +39031,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39014,6 +39065,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39140,6 +39192,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39193,6 +39246,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39246,6 +39300,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -41493,6 +41548,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -41552,6 +41608,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47213,6 +47270,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47246,6 +47304,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47279,6 +47338,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47312,6 +47372,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47355,6 +47416,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47388,6 +47450,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47421,6 +47484,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47454,6 +47518,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47487,6 +47552,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47520,6 +47586,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47553,6 +47620,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47586,6 +47654,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -49098,6 +49167,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -49131,6 +49201,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -49164,6 +49235,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58140,6 +58212,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58173,6 +58246,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58224,6 +58298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58265,6 +58340,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58306,6 +58382,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58339,6 +58416,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58372,6 +58450,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58405,6 +58484,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58438,6 +58518,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58471,6 +58552,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58597,6 +58679,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58650,6 +58733,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58703,6 +58787,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -60716,6 +60801,7 @@ get names(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -65276,6 +65362,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -65335,6 +65422,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -66086,6 +66174,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -66886,6 +66975,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72716,6 +72806,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72749,6 +72840,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72800,6 +72892,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72841,6 +72934,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72882,6 +72976,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72915,6 +73010,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72948,6 +73044,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72981,6 +73078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73014,6 +73112,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73047,6 +73146,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73173,6 +73273,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73226,6 +73327,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73279,6 +73381,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -79887,6 +79990,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -79920,6 +80024,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -79971,6 +80076,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80012,6 +80118,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80053,6 +80160,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80086,6 +80194,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80119,6 +80228,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80152,6 +80262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80185,6 +80296,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80218,6 +80330,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80344,6 +80457,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80397,6 +80511,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80450,6 +80565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -82672,6 +82788,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84374,6 +84491,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84407,6 +84525,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84489,6 +84608,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84548,6 +84668,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -86952,6 +87073,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -86985,6 +87107,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -87018,6 +87141,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93187,6 +93311,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93220,6 +93345,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93271,6 +93397,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93312,6 +93439,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93353,6 +93481,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93386,6 +93515,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93419,6 +93549,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93452,6 +93583,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93485,6 +93617,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93518,6 +93651,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93644,6 +93778,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93697,6 +93832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93750,6 +93886,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10344,9 +10344,14 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -10645,16 +10650,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10691,23 +10696,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10742,7 +10747,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10802,12 +10807,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10891,12 +10896,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10927,7 +10932,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: _baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10953,7 +10958,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10982,7 +10987,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: _baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11008,7 +11013,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11044,12 +11049,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11087,12 +11092,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11130,12 +11135,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11192,7 +11197,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11225,7 +11230,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11258,7 +11263,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11291,7 +11296,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11373,12 +11378,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11437,13 +11442,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], _baseUrl) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11478,7 +11483,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11511,7 +11516,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11544,7 +11549,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11577,7 +11582,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11652,7 +11657,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11685,7 +11690,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11706,7 +11711,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11738,9 +11743,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11772,7 +11777,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11805,7 +11810,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11838,7 +11843,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13016,9 +13021,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -14022,9 +14032,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -14073,7 +14088,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14132,7 +14147,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17079,9 +17094,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -17268,23 +17288,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17319,7 +17339,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17352,7 +17372,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17385,7 +17405,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17418,7 +17438,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17451,7 +17471,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17922,9 +17942,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -18425,9 +18450,14 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -19011,9 +19041,14 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -20010,9 +20045,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -20061,7 +20101,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20094,7 +20134,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20459,9 +20499,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21050,9 +21095,14 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21084,7 +21134,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21105,7 +21155,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21126,7 +21176,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21147,7 +21197,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21798,9 +21848,14 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21843,9 +21898,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21876,9 +21931,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22838,9 +22893,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -22889,7 +22949,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22922,7 +22982,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23286,9 +23346,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -24198,9 +24263,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -24249,7 +24319,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24282,7 +24352,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24646,9 +24716,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25557,9 +25632,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25608,7 +25688,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25641,7 +25721,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26005,9 +26085,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26450,9 +26535,14 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26499,9 +26589,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26803,9 +26893,14 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27621,9 +27716,14 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27685,7 +27785,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28590,9 +28690,14 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -28638,23 +28743,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29472,9 +29577,14 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -29520,23 +29630,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30307,9 +30417,14 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -30370,9 +30485,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30392,7 +30507,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30413,7 +30528,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30434,7 +30549,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31179,9 +31294,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -31236,7 +31356,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31257,7 +31377,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31672,9 +31792,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32012,9 +32137,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32347,9 +32477,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -37928,9 +38063,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -38003,7 +38143,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38036,7 +38176,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38089,11 +38229,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38130,11 +38270,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38169,7 +38309,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38202,7 +38342,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38235,7 +38375,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38268,7 +38408,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38301,7 +38441,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38334,7 +38474,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38355,7 +38495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38462,23 +38602,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38515,23 +38655,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38566,7 +38706,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39391,9 +39531,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -39738,9 +39883,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40739,9 +40889,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40790,7 +40945,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40849,7 +41004,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41380,9 +41535,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -41809,9 +41969,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42143,9 +42308,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42483,9 +42653,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -46330,9 +46505,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -46411,7 +46591,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46444,7 +46624,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46477,7 +46657,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46513,12 +46693,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46553,7 +46733,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46586,7 +46766,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46619,7 +46799,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46652,7 +46832,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46685,7 +46865,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46718,7 +46898,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46751,7 +46931,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46784,7 +46964,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48217,9 +48397,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -48272,7 +48457,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48305,7 +48490,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48338,7 +48523,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48712,9 +48897,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49046,9 +49236,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49378,9 +49573,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50172,9 +50372,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50217,9 +50422,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50250,9 +50455,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50283,9 +50488,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50316,9 +50521,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50349,9 +50554,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50382,9 +50587,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50837,9 +51042,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51172,9 +51382,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51508,9 +51723,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -57089,9 +57309,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -57164,7 +57389,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57197,7 +57422,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57250,11 +57475,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57291,11 +57516,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57330,7 +57555,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57363,7 +57588,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57396,7 +57621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57429,7 +57654,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57462,7 +57687,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57495,7 +57720,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57516,7 +57741,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57623,23 +57848,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57676,23 +57901,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57727,7 +57952,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59522,9 +59747,14 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -59575,9 +59805,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59726,12 +59956,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60205,9 +60435,14 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -60542,9 +60777,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -60877,9 +61117,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61215,9 +61460,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61549,9 +61799,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61883,9 +62138,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62217,9 +62477,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62549,9 +62814,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62847,9 +63117,14 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63182,9 +63457,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -64185,9 +64465,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -64236,7 +64521,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64295,7 +64580,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64985,9 +65270,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -65039,12 +65329,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65775,9 +66065,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -65829,12 +66124,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71459,9 +71754,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -71534,7 +71834,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71567,7 +71867,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71620,11 +71920,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71661,11 +71961,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71700,7 +72000,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71733,7 +72033,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71766,7 +72066,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71799,7 +72099,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71832,7 +72132,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71865,7 +72165,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71886,7 +72186,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71993,23 +72293,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72046,23 +72346,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72097,7 +72397,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72924,9 +73224,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -78505,9 +78810,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -78580,7 +78890,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78613,7 +78923,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78666,11 +78976,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78707,11 +79017,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78746,7 +79056,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78779,7 +79089,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78812,7 +79122,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78845,7 +79155,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78878,7 +79188,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78911,7 +79221,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78932,7 +79242,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79039,23 +79349,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79092,23 +79402,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79143,7 +79453,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80426,9 +80736,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -80570,9 +80885,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
+          : new URL(v[\\"@id\\"], _baseUrl) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81301,9 +81616,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -81352,7 +81672,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82972,9 +83292,14 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -83023,7 +83348,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83056,7 +83381,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83138,7 +83463,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83197,7 +83522,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83656,9 +83981,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -83990,9 +84320,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -85506,9 +85841,14 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -85557,7 +85897,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85590,7 +85930,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85623,7 +85963,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86011,9 +86351,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -91592,9 +91937,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -91667,7 +92017,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91700,7 +92050,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91753,11 +92103,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91794,11 +92144,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91833,7 +92183,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91866,7 +92216,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91899,7 +92249,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91932,7 +92282,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91965,7 +92315,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91998,7 +92348,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92019,7 +92369,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92126,23 +92476,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92179,23 +92529,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92230,7 +92580,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93266,9 +93616,14 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -93698,9 +94053,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94032,9 +94392,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94582,9 +94947,14 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95017,9 +95387,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95356,9 +95731,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95693,9 +96073,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96030,9 +96415,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96363,9 +96753,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -3679,23 +3679,25 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === \\"object\\") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       
-          {
-            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as Image;
-          }
+            {
+              const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as Image;
+            }
         
+          }
         }
       
         try {
@@ -4024,23 +4026,25 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === \\"object\\") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       
-          {
-            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as Image;
-          }
+            {
+              const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as Image;
+            }
         
+          }
         }
       
         try {
@@ -10591,16 +10595,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10637,23 +10641,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10688,7 +10692,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10748,12 +10752,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10837,12 +10841,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10873,7 +10877,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10899,7 +10903,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10928,7 +10932,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10954,7 +10958,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10990,12 +10994,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11033,12 +11037,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11076,12 +11080,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11138,7 +11142,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11171,7 +11175,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11204,7 +11208,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11237,7 +11241,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11319,12 +11323,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11383,13 +11387,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11424,7 +11428,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11457,7 +11461,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11490,7 +11494,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11523,7 +11527,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11598,7 +11602,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11631,7 +11635,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11652,7 +11656,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11684,9 +11688,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11718,7 +11722,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11751,7 +11755,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11784,7 +11788,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -14015,7 +14019,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14074,7 +14078,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17186,23 +17190,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17237,7 +17241,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17270,7 +17274,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17303,7 +17307,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17336,7 +17340,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17369,7 +17373,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19975,7 +19979,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20008,7 +20012,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20998,7 +21002,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21019,7 +21023,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21040,7 +21044,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21061,7 +21065,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21757,9 +21761,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21790,9 +21794,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22799,7 +22803,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22832,7 +22836,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24155,7 +24159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24188,7 +24192,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25510,7 +25514,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25543,7 +25547,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26401,9 +26405,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27587,7 +27591,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28538,23 +28542,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29418,23 +29422,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30268,9 +30272,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30290,7 +30294,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30311,7 +30315,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30332,7 +30336,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31134,7 +31138,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31155,7 +31159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37867,7 +37871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37900,7 +37904,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37953,11 +37957,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37994,11 +37998,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38033,7 +38037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38066,7 +38070,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38099,7 +38103,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38132,7 +38136,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38165,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38198,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38219,7 +38223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38326,23 +38330,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38379,23 +38383,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38430,7 +38434,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40650,7 +40654,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40709,7 +40713,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46247,7 +46251,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46280,7 +46284,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46313,7 +46317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46349,12 +46353,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46389,7 +46393,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46422,7 +46426,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46455,7 +46459,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46488,7 +46492,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46521,7 +46525,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46554,7 +46558,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46587,7 +46591,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46620,7 +46624,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48102,7 +48106,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48135,7 +48139,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48168,7 +48172,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -50047,9 +50051,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50080,9 +50084,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50113,9 +50117,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50146,9 +50150,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50179,9 +50183,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50212,9 +50216,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56960,7 +56964,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56993,7 +56997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57046,11 +57050,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57087,11 +57091,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57126,7 +57130,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57159,7 +57163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57192,7 +57196,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57225,7 +57229,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57258,7 +57262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57291,7 +57295,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57312,7 +57316,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57419,23 +57423,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57472,23 +57476,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57523,7 +57527,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59369,9 +59373,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59520,12 +59524,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -64026,7 +64030,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64085,7 +64089,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64827,12 +64831,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65615,12 +65619,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71286,7 +71290,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71319,7 +71323,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71372,11 +71376,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71413,11 +71417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71452,7 +71456,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71485,7 +71489,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71518,7 +71522,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71551,7 +71555,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71584,7 +71588,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71617,7 +71621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71638,7 +71642,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71745,23 +71749,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71798,23 +71802,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71849,7 +71853,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -78298,7 +78302,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78331,7 +78335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78384,11 +78388,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78425,11 +78429,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78464,7 +78468,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78497,7 +78501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78530,7 +78534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78563,7 +78567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78596,7 +78600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78629,7 +78633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78650,7 +78654,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78757,23 +78761,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78810,23 +78814,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78861,7 +78865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80288,9 +80292,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81068,7 +81072,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82731,7 +82735,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82764,7 +82768,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82846,7 +82850,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82905,7 +82909,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -85255,7 +85259,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85288,7 +85292,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85321,7 +85325,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -91331,7 +91335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91364,7 +91368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91417,11 +91421,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91458,11 +91462,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91497,7 +91501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91530,7 +91534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91563,7 +91567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91596,7 +91600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91629,7 +91633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91662,7 +91666,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91683,7 +91687,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91790,23 +91794,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91843,23 +91847,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91894,7 +91898,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10344,7 +10344,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -10645,16 +10645,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10691,23 +10691,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10742,7 +10742,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10802,12 +10802,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10891,12 +10891,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10927,7 +10927,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10953,7 +10953,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10982,7 +10982,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11008,7 +11008,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11044,12 +11044,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11087,12 +11087,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11130,12 +11130,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11192,7 +11192,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11225,7 +11225,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11258,7 +11258,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11291,7 +11291,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11373,12 +11373,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11437,13 +11437,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11478,7 +11478,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11511,7 +11511,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11544,7 +11544,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11577,7 +11577,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11652,7 +11652,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11685,7 +11685,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11706,7 +11706,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11738,9 +11738,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11772,7 +11772,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11805,7 +11805,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11838,7 +11838,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13016,7 +13016,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -14022,7 +14022,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -14073,7 +14073,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14132,7 +14132,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17079,7 +17079,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -17268,23 +17268,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17319,7 +17319,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17352,7 +17352,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17385,7 +17385,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17418,7 +17418,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17451,7 +17451,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17922,7 +17922,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18425,7 +18425,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19011,7 +19011,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20010,7 +20010,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20061,7 +20061,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20094,7 +20094,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20459,7 +20459,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21050,7 +21050,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21084,7 +21084,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21105,7 +21105,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21126,7 +21126,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21147,7 +21147,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21798,7 +21798,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21843,9 +21843,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21876,9 +21876,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22838,7 +22838,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -22889,7 +22889,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22922,7 +22922,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23286,7 +23286,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24198,7 +24198,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24249,7 +24249,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24282,7 +24282,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24646,7 +24646,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25557,7 +25557,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25608,7 +25608,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25641,7 +25641,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26005,7 +26005,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26450,7 +26450,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26499,9 +26499,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26803,7 +26803,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27621,7 +27621,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27685,7 +27685,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28590,7 +28590,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -28638,23 +28638,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29472,7 +29472,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -29520,23 +29520,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30307,7 +30307,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30370,9 +30370,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30392,7 +30392,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30413,7 +30413,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30434,7 +30434,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31179,7 +31179,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31236,7 +31236,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31257,7 +31257,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31672,7 +31672,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32012,7 +32012,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32347,7 +32347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37928,7 +37928,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -38003,7 +38003,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38036,7 +38036,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38089,11 +38089,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38130,11 +38130,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38169,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38202,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38235,7 +38235,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38268,7 +38268,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38301,7 +38301,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38334,7 +38334,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38355,7 +38355,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38462,23 +38462,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38515,23 +38515,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38566,7 +38566,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39391,7 +39391,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39738,7 +39738,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40739,7 +40739,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40790,7 +40790,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40849,7 +40849,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41380,7 +41380,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41809,7 +41809,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42143,7 +42143,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42483,7 +42483,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46330,7 +46330,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46411,7 +46411,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46444,7 +46444,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46477,7 +46477,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46513,12 +46513,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46553,7 +46553,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46586,7 +46586,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46619,7 +46619,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46652,7 +46652,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46685,7 +46685,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46718,7 +46718,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46751,7 +46751,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46784,7 +46784,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48217,7 +48217,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48272,7 +48272,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48305,7 +48305,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48338,7 +48338,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48712,7 +48712,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49046,7 +49046,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49378,7 +49378,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50172,7 +50172,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50217,9 +50217,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50250,9 +50250,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50283,9 +50283,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50316,9 +50316,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50349,9 +50349,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50382,9 +50382,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50837,7 +50837,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51172,7 +51172,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51508,7 +51508,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -57089,7 +57089,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -57164,7 +57164,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57197,7 +57197,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57250,11 +57250,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57291,11 +57291,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57330,7 +57330,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57363,7 +57363,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57396,7 +57396,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57429,7 +57429,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57462,7 +57462,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57495,7 +57495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57516,7 +57516,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57623,23 +57623,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57676,23 +57676,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57727,7 +57727,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59522,7 +59522,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59575,9 +59575,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59726,12 +59726,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60205,7 +60205,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60542,7 +60542,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60877,7 +60877,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61215,7 +61215,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61549,7 +61549,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61883,7 +61883,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62217,7 +62217,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62549,7 +62549,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62847,7 +62847,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63182,7 +63182,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64185,7 +64185,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64236,7 +64236,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64295,7 +64295,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64985,7 +64985,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65039,12 +65039,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65775,7 +65775,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65829,12 +65829,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71459,7 +71459,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -71534,7 +71534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71567,7 +71567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71620,11 +71620,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71661,11 +71661,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71700,7 +71700,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71733,7 +71733,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71766,7 +71766,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71799,7 +71799,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71832,7 +71832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71865,7 +71865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71886,7 +71886,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71993,23 +71993,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72046,23 +72046,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72097,7 +72097,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72924,7 +72924,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78505,7 +78505,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78580,7 +78580,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78613,7 +78613,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78666,11 +78666,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78707,11 +78707,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78746,7 +78746,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78779,7 +78779,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78812,7 +78812,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78845,7 +78845,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78878,7 +78878,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78911,7 +78911,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78932,7 +78932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79039,23 +79039,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79092,23 +79092,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79143,7 +79143,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80426,7 +80426,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -80570,9 +80570,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81301,7 +81301,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -81352,7 +81352,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82972,7 +82972,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83023,7 +83023,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83056,7 +83056,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83138,7 +83138,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83197,7 +83197,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83656,7 +83656,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83990,7 +83990,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85506,7 +85506,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85557,7 +85557,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85590,7 +85590,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85623,7 +85623,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86011,7 +86011,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91592,7 +91592,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91667,7 +91667,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91700,7 +91700,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91753,11 +91753,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91794,11 +91794,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91833,7 +91833,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91866,7 +91866,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91899,7 +91899,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91932,7 +91932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91965,7 +91965,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91998,7 +91998,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92019,7 +92019,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92126,23 +92126,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92179,23 +92179,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92230,7 +92230,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93266,7 +93266,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93698,7 +93698,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94032,7 +94032,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94582,7 +94582,7 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95017,7 +95017,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95356,7 +95356,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95693,7 +95693,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -96030,7 +96030,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -96363,7 +96363,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -3663,18 +3663,26 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        {
-          const _ppM0 = await import(\\"./preprocessors.ts\\");
-          const _result = await _ppM0[\\"normalizeLinkToImage\\"](jsonLd as any, {
-            documentLoader,
-            contextLoader,
-            tracerProvider,
-            baseUrl,
-          });
-          if (_result instanceof Error) throw _result;
-          if (_result !== undefined) return _result as Image;
-        }
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      
+          {
+            const _ppM0 = await import(\\"./preprocessors.ts\\");
+            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as Image;
+          }
         
+        }
+      
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -3989,18 +3997,26 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        {
-          const _ppM0 = await import(\\"./preprocessors.ts\\");
-          const _result = await _ppM0[\\"normalizeLinkToImage\\"](jsonLd as any, {
-            documentLoader,
-            contextLoader,
-            tracerProvider,
-            baseUrl,
-          });
-          if (_result instanceof Error) throw _result;
-          if (_result !== undefined) return _result as Image;
-        }
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      
+          {
+            const _ppM0 = await import(\\"./preprocessors.ts\\");
+            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as Image;
+          }
         
+        }
+      
         try {
           return await Image.fromJsonLd(
             jsonLd,

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10717,9 +10717,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -10776,9 +10784,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -10849,9 +10865,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -10910,9 +10934,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11007,9 +11039,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11084,9 +11124,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11147,9 +11195,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11184,9 +11240,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11235,9 +11299,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11286,9 +11358,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11359,9 +11439,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11396,9 +11484,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11433,9 +11529,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11470,9 +11574,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11553,9 +11665,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11681,9 +11801,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11718,9 +11846,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11755,9 +11891,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11792,9 +11936,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11908,9 +12060,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -12011,9 +12171,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -12048,9 +12216,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -12085,9 +12261,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -14334,9 +14518,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -14397,9 +14589,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17562,9 +17762,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17635,9 +17843,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17672,9 +17888,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17709,9 +17933,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17746,9 +17978,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17783,9 +18023,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -20427,9 +20675,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -20464,9 +20720,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -23325,9 +23589,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -23362,9 +23634,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -24703,9 +24983,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -24740,9 +25028,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -26080,9 +26376,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -26117,9 +26421,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -28199,9 +28511,17 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -29166,9 +29486,17 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -30080,9 +30408,17 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38672,9 +39008,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38709,9 +39053,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38764,9 +39116,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38813,9 +39173,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38862,9 +39230,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38899,9 +39275,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38936,9 +39320,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38973,9 +39365,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39010,9 +39410,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39047,9 +39455,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39181,9 +39597,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39254,9 +39678,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39327,9 +39759,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -41568,9 +42008,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -41631,9 +42079,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47236,9 +47692,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47273,9 +47737,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47310,9 +47782,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47347,9 +47827,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47398,9 +47886,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47435,9 +47931,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47472,9 +47976,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47509,9 +48021,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47546,9 +48066,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47583,9 +48111,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47620,9 +48156,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47657,9 +48201,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -49158,9 +49710,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -49195,9 +49755,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -49232,9 +49800,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58175,9 +58751,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58212,9 +58796,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58267,9 +58859,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58316,9 +58916,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58365,9 +58973,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58402,9 +59018,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58439,9 +59063,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58476,9 +59108,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58513,9 +59153,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58550,9 +59198,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58684,9 +59340,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58757,9 +59421,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58830,9 +59502,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -60850,9 +61530,17 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -65408,9 +66096,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -65471,9 +66167,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -66221,9 +66925,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -67024,9 +67736,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72777,9 +73497,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72814,9 +73542,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72869,9 +73605,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72918,9 +73662,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72967,9 +73719,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73004,9 +73764,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73041,9 +73809,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73078,9 +73854,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73115,9 +73899,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73152,9 +73944,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73286,9 +74086,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73359,9 +74167,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73432,9 +74248,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -79959,9 +80783,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -79996,9 +80828,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80051,9 +80891,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80100,9 +80948,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80149,9 +81005,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80186,9 +81050,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80223,9 +81095,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80260,9 +81140,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80297,9 +81185,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80334,9 +81230,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80468,9 +81372,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80541,9 +81453,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80614,9 +81534,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -82843,9 +83771,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84529,9 +85465,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84566,9 +85510,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84652,9 +85604,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84715,9 +85675,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -87098,9 +88066,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -87135,9 +88111,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -87172,9 +88156,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93260,9 +94252,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93297,9 +94297,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93352,9 +94360,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93401,9 +94417,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93450,9 +94474,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93487,9 +94519,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93524,9 +94564,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93561,9 +94609,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93598,9 +94654,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93635,9 +94699,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93769,9 +94841,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93842,9 +94922,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93915,9 +95003,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10425,8 +10425,8 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -10693,7 +10693,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     
@@ -10728,26 +10728,26 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10786,41 +10786,41 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10857,9 +10857,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10921,18 +10921,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11018,18 +11018,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11062,9 +11062,9 @@ get urls(): ((URL | Link))[] {
             tracerProvider: options.tracerProvider,
             baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
+        : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11092,9 +11092,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11125,9 +11125,9 @@ get urls(): ((URL | Link))[] {
             tracerProvider: options.tracerProvider,
             baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
+        : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11155,9 +11155,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11195,18 +11195,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11246,18 +11246,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11297,18 +11297,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11367,9 +11367,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11404,9 +11404,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11441,9 +11441,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11478,9 +11478,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11564,18 +11564,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11636,23 +11636,23 @@ get urls(): ((URL | Link))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+        : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11689,9 +11689,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11726,9 +11726,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11763,9 +11763,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11800,9 +11800,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11879,9 +11879,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11916,9 +11916,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11941,9 +11941,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11977,15 +11977,15 @@ get urls(): ((URL | Link))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12019,9 +12019,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12056,9 +12056,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12093,9 +12093,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13273,8 +13273,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -14283,8 +14283,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -14336,9 +14336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14399,9 +14399,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17372,8 +17372,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -17563,41 +17563,41 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17634,9 +17634,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17671,9 +17671,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17708,9 +17708,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17745,9 +17745,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17782,9 +17782,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -18255,8 +18255,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -18765,8 +18765,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -18781,7 +18781,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19358,8 +19358,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -19374,7 +19374,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -20361,8 +20361,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -20414,9 +20414,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20451,9 +20451,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20818,8 +20818,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -21416,8 +21416,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -21432,7 +21432,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21452,9 +21452,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21477,9 +21477,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21502,9 +21502,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21527,9 +21527,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -22187,8 +22187,8 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -22203,7 +22203,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -22234,15 +22234,15 @@ get manualApprovals(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -22275,15 +22275,15 @@ get manualApprovals(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -23247,8 +23247,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -23300,9 +23300,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -23337,9 +23337,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23703,8 +23703,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -24619,8 +24619,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -24672,9 +24672,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24709,9 +24709,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25075,8 +25075,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -25990,8 +25990,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -26043,9 +26043,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26080,9 +26080,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26446,8 +26446,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -26898,8 +26898,8 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -26918,7 +26918,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -26949,15 +26949,15 @@ get endpoints(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27259,8 +27259,8 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -28084,8 +28084,8 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -28100,7 +28100,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28150,9 +28150,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -29066,8 +29066,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -29082,7 +29082,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     
@@ -29116,41 +29116,41 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29977,8 +29977,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -29993,7 +29993,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     
@@ -30027,41 +30027,41 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30839,8 +30839,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -30855,7 +30855,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -30904,15 +30904,15 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30934,9 +30934,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30959,9 +30959,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30984,9 +30984,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31731,8 +31731,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -31790,9 +31790,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31815,9 +31815,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -32232,8 +32232,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -32572,8 +32572,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -32907,8 +32907,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -38522,8 +38522,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -38599,9 +38599,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38636,9 +38636,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38693,17 +38693,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38742,17 +38742,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38789,9 +38789,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38826,9 +38826,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38863,9 +38863,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38900,9 +38900,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38937,9 +38937,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38974,9 +38974,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38999,9 +38999,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -39110,41 +39110,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39183,41 +39183,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39254,9 +39254,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40081,8 +40081,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -40428,8 +40428,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -41433,8 +41433,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -41486,9 +41486,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -41549,9 +41549,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -42082,8 +42082,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -42511,8 +42511,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -42845,8 +42845,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -43185,8 +43185,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -47056,8 +47056,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -47139,9 +47139,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -47176,9 +47176,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -47213,9 +47213,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -47253,18 +47253,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -47301,9 +47301,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -47338,9 +47338,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -47375,9 +47375,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -47412,9 +47412,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -47449,9 +47449,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -47486,9 +47486,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -47523,9 +47523,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -47560,9 +47560,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -49001,8 +49001,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -49058,9 +49058,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -49095,9 +49095,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -49132,9 +49132,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -49508,8 +49508,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -49842,8 +49842,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -50174,8 +50174,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -50975,8 +50975,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -50991,7 +50991,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -51022,15 +51022,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -51063,15 +51063,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -51104,15 +51104,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -51145,15 +51145,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -51186,15 +51186,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -51227,15 +51227,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -51688,8 +51688,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -52023,8 +52023,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -52359,8 +52359,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -57974,8 +57974,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -58051,9 +58051,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -58088,9 +58088,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -58145,17 +58145,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58194,17 +58194,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58241,9 +58241,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -58278,9 +58278,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -58315,9 +58315,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -58352,9 +58352,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -58389,9 +58389,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -58426,9 +58426,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -58451,9 +58451,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -58562,41 +58562,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58635,41 +58635,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58706,9 +58706,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -60512,8 +60512,8 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -60536,7 +60536,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -60567,15 +60567,15 @@ get names(): ((string | LanguageString))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -60726,18 +60726,18 @@ get names(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61211,8 +61211,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -61548,8 +61548,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -61883,8 +61883,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -62221,8 +62221,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -62555,8 +62555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -62889,8 +62889,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -63223,8 +63223,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -63555,8 +63555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -63853,8 +63853,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -64188,8 +64188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -65195,8 +65195,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -65248,9 +65248,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -65311,9 +65311,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -66005,8 +66005,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -66061,18 +66061,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -66805,8 +66805,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -66861,18 +66861,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72531,8 +72531,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -72608,9 +72608,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -72645,9 +72645,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -72702,17 +72702,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72751,17 +72751,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72798,9 +72798,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -72835,9 +72835,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -72872,9 +72872,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -72909,9 +72909,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -72946,9 +72946,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -72983,9 +72983,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -73008,9 +73008,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -73119,41 +73119,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73192,41 +73192,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73263,9 +73263,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -74092,8 +74092,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -79707,8 +79707,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -79784,9 +79784,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -79821,9 +79821,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -79878,17 +79878,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79927,17 +79927,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79974,9 +79974,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -80011,9 +80011,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -80048,9 +80048,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -80085,9 +80085,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -80122,9 +80122,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -80159,9 +80159,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -80184,9 +80184,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -80295,41 +80295,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -80368,41 +80368,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -80439,9 +80439,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -81724,8 +81724,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -81870,15 +81870,15 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : undefined
+        : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -82609,8 +82609,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -82662,9 +82662,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -84292,8 +84292,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -84345,9 +84345,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -84382,9 +84382,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -84468,9 +84468,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -84531,9 +84531,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -84992,8 +84992,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -85326,8 +85326,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -86852,8 +86852,8 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -86905,9 +86905,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -86942,9 +86942,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -86979,9 +86979,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -87369,8 +87369,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -92984,8 +92984,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -93061,9 +93061,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -93098,9 +93098,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -93155,17 +93155,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93204,17 +93204,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93251,9 +93251,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -93288,9 +93288,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -93325,9 +93325,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -93362,9 +93362,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -93399,9 +93399,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -93436,9 +93436,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -93461,9 +93461,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -93572,41 +93572,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93645,41 +93645,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93716,9 +93716,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -94761,8 +94761,8 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -94777,7 +94777,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -95193,8 +95193,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -95527,8 +95527,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -96077,8 +96077,8 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -96512,8 +96512,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -96851,8 +96851,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -97188,8 +97188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -97525,8 +97525,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -97858,8 +97858,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10294,7 +10294,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -10595,16 +10595,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10641,23 +10641,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10692,7 +10692,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10752,12 +10752,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10841,12 +10841,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10877,7 +10877,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10903,7 +10903,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10932,7 +10932,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10958,7 +10958,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10994,12 +10994,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11037,12 +11037,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11080,12 +11080,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11142,7 +11142,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11175,7 +11175,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11208,7 +11208,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11241,7 +11241,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11323,12 +11323,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11387,13 +11387,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11428,7 +11428,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11461,7 +11461,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11494,7 +11494,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11527,7 +11527,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11602,7 +11602,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11635,7 +11635,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11656,7 +11656,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11688,9 +11688,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11722,7 +11722,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11755,7 +11755,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11788,7 +11788,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -12966,7 +12966,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -13968,7 +13968,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -14019,7 +14019,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14078,7 +14078,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17001,7 +17001,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -17190,23 +17190,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17241,7 +17241,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17274,7 +17274,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17307,7 +17307,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17340,7 +17340,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17373,7 +17373,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17844,7 +17844,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18347,7 +18347,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18933,7 +18933,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19928,7 +19928,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19979,7 +19979,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20012,7 +20012,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20377,7 +20377,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20968,7 +20968,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21002,7 +21002,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21023,7 +21023,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21044,7 +21044,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21065,7 +21065,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21716,7 +21716,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21761,9 +21761,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21794,9 +21794,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22752,7 +22752,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -22803,7 +22803,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22836,7 +22836,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23200,7 +23200,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24108,7 +24108,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24159,7 +24159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24192,7 +24192,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24556,7 +24556,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25463,7 +25463,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25514,7 +25514,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25547,7 +25547,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25911,7 +25911,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26356,7 +26356,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26405,9 +26405,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26709,7 +26709,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27527,7 +27527,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27591,7 +27591,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28494,7 +28494,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -28542,23 +28542,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29374,7 +29374,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -29422,23 +29422,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30209,7 +30209,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30272,9 +30272,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30294,7 +30294,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30315,7 +30315,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30336,7 +30336,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31081,7 +31081,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31138,7 +31138,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31159,7 +31159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31574,7 +31574,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31914,7 +31914,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32249,7 +32249,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37796,7 +37796,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37871,7 +37871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37904,7 +37904,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37957,11 +37957,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37998,11 +37998,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38037,7 +38037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38070,7 +38070,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38103,7 +38103,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38136,7 +38136,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38169,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38202,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38223,7 +38223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38330,23 +38330,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38383,23 +38383,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38434,7 +38434,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39259,7 +39259,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39606,7 +39606,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40603,7 +40603,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40654,7 +40654,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40713,7 +40713,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41244,7 +41244,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41673,7 +41673,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42007,7 +42007,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42347,7 +42347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46170,7 +46170,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46251,7 +46251,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46284,7 +46284,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46317,7 +46317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46353,12 +46353,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46393,7 +46393,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46426,7 +46426,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46459,7 +46459,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46492,7 +46492,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46525,7 +46525,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46558,7 +46558,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46591,7 +46591,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46624,7 +46624,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48051,7 +48051,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48106,7 +48106,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48139,7 +48139,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48172,7 +48172,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48546,7 +48546,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48880,7 +48880,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49212,7 +49212,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50006,7 +50006,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50051,9 +50051,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50084,9 +50084,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50117,9 +50117,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50150,9 +50150,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50183,9 +50183,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50216,9 +50216,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50671,7 +50671,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51006,7 +51006,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51342,7 +51342,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56889,7 +56889,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56964,7 +56964,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56997,7 +56997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57050,11 +57050,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57091,11 +57091,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57130,7 +57130,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57163,7 +57163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57196,7 +57196,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57229,7 +57229,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57262,7 +57262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57295,7 +57295,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57316,7 +57316,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57423,23 +57423,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57476,23 +57476,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57527,7 +57527,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59320,7 +59320,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59373,9 +59373,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59524,12 +59524,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60003,7 +60003,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60340,7 +60340,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60675,7 +60675,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61013,7 +61013,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61347,7 +61347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61681,7 +61681,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62015,7 +62015,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62347,7 +62347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62645,7 +62645,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62980,7 +62980,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63979,7 +63979,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64030,7 +64030,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64089,7 +64089,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64777,7 +64777,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64831,12 +64831,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65565,7 +65565,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65619,12 +65619,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71215,7 +71215,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -71290,7 +71290,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71323,7 +71323,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71376,11 +71376,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71417,11 +71417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71456,7 +71456,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71489,7 +71489,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71522,7 +71522,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71555,7 +71555,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71588,7 +71588,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71621,7 +71621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71642,7 +71642,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71749,23 +71749,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71802,23 +71802,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71853,7 +71853,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72680,7 +72680,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78227,7 +78227,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78302,7 +78302,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78335,7 +78335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78388,11 +78388,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78429,11 +78429,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78468,7 +78468,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78501,7 +78501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78534,7 +78534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78567,7 +78567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78600,7 +78600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78633,7 +78633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78654,7 +78654,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78761,23 +78761,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78814,23 +78814,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78865,7 +78865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80148,7 +80148,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -80292,9 +80292,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81021,7 +81021,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -81072,7 +81072,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82684,7 +82684,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -82735,7 +82735,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82768,7 +82768,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82850,7 +82850,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82909,7 +82909,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83368,7 +83368,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83702,7 +83702,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85208,7 +85208,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85259,7 +85259,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85292,7 +85292,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85325,7 +85325,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -85713,7 +85713,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91260,7 +91260,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91335,7 +91335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91368,7 +91368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91421,11 +91421,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91462,11 +91462,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91501,7 +91501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91534,7 +91534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91567,7 +91567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91600,7 +91600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91633,7 +91633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91666,7 +91666,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91687,7 +91687,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91794,23 +91794,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91847,23 +91847,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91898,7 +91898,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -92934,7 +92934,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93366,7 +93366,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93700,7 +93700,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94250,7 +94250,7 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94685,7 +94685,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95024,7 +95024,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95361,7 +95361,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95698,7 +95698,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -96031,7 +96031,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10290,7 +10290,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -10558,7 +10558,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -12962,7 +12962,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -13964,7 +13964,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -16997,7 +16997,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -17840,7 +17840,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18343,7 +18343,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18359,7 +18359,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -18929,7 +18929,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18945,7 +18945,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -19924,7 +19924,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20373,7 +20373,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20964,7 +20964,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20980,7 +20980,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21712,7 +21712,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21728,7 +21728,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -22748,7 +22748,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -23196,7 +23196,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24104,7 +24104,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24552,7 +24552,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25459,7 +25459,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25907,7 +25907,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26352,7 +26352,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26372,7 +26372,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -26705,7 +26705,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27523,7 +27523,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27539,7 +27539,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28490,7 +28490,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -28506,7 +28506,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -29370,7 +29370,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -29386,7 +29386,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -30205,7 +30205,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30221,7 +30221,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -31077,7 +31077,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31570,7 +31570,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31910,7 +31910,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32245,7 +32245,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37792,7 +37792,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39255,7 +39255,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39602,7 +39602,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40599,7 +40599,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41240,7 +41240,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41669,7 +41669,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42003,7 +42003,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42343,7 +42343,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46166,7 +46166,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48047,7 +48047,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48542,7 +48542,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48876,7 +48876,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49208,7 +49208,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50002,7 +50002,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50018,7 +50018,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -50667,7 +50667,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51002,7 +51002,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51338,7 +51338,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56885,7 +56885,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59316,7 +59316,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59340,7 +59340,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -59999,7 +59999,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60336,7 +60336,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60671,7 +60671,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61009,7 +61009,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61343,7 +61343,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61677,7 +61677,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62011,7 +62011,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62343,7 +62343,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62641,7 +62641,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62976,7 +62976,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63975,7 +63975,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64773,7 +64773,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65561,7 +65561,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -71211,7 +71211,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -72676,7 +72676,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78223,7 +78223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -80144,7 +80144,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -81017,7 +81017,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -82680,7 +82680,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83364,7 +83364,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83698,7 +83698,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85204,7 +85204,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85709,7 +85709,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91256,7 +91256,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -92930,7 +92930,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -92946,7 +92946,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -93362,7 +93362,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93696,7 +93696,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94246,7 +94246,7 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94681,7 +94681,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95020,7 +95020,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95357,7 +95357,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95694,7 +95694,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -96027,7 +96027,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10425,6 +10425,9 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -13273,6 +13276,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -14282,6 +14288,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -17372,6 +17381,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -18255,6 +18267,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -18764,6 +18779,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -19357,6 +19375,9 @@ unit?: string | null;numericalValue?: Decimal | null;}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -20361,6 +20382,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -20817,6 +20841,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -21415,6 +21442,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -22186,6 +22216,9 @@ get manualApprovals(): (URL)[] {
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -23247,6 +23280,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -23702,6 +23738,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -24619,6 +24658,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -25074,6 +25116,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -25990,6 +26035,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -26446,6 +26494,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -26898,6 +26949,9 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -27258,6 +27312,9 @@ endpoints?: (URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -28083,6 +28140,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -29066,6 +29126,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -29977,6 +30040,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -30838,6 +30904,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -31731,6 +31800,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -32232,6 +32304,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -32572,6 +32647,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -32906,6 +32984,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -38522,6 +38603,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -40081,6 +40165,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -40427,6 +40514,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -41433,6 +41523,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -42082,6 +42175,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -42511,6 +42607,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -42844,6 +42943,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -43184,6 +43286,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -47056,6 +47161,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -49001,6 +49109,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -49508,6 +49619,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -49842,6 +49956,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -50173,6 +50290,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -50975,6 +51095,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -51688,6 +51811,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -52022,6 +52148,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -52358,6 +52487,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -57974,6 +58106,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -60512,6 +60647,9 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -61211,6 +61349,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -61548,6 +61689,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -61882,6 +62026,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -62221,6 +62368,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -62554,6 +62704,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -62889,6 +63042,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -63223,6 +63379,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -63555,6 +63714,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -63852,6 +64014,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -64187,6 +64352,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -65195,6 +65363,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -66005,6 +66176,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -66804,6 +66978,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -72531,6 +72708,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -74091,6 +74271,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -79707,6 +79890,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -81724,6 +81910,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -82608,6 +82797,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -84292,6 +84484,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -84992,6 +85187,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -85325,6 +85523,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -86852,6 +87053,9 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -87368,6 +87572,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -92984,6 +93191,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -94761,6 +94971,9 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -95193,6 +95406,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -95526,6 +95742,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -96077,6 +96296,9 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -96512,6 +96734,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -96851,6 +97076,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -97187,6 +97415,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -97525,6 +97756,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -97857,6 +98091,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10425,7 +10425,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -13273,7 +13273,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -14283,7 +14283,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -17372,7 +17372,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -18255,7 +18255,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -18765,7 +18765,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -19358,7 +19358,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -20361,7 +20361,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -20818,7 +20818,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -21416,7 +21416,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -22187,7 +22187,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -23247,7 +23247,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -23703,7 +23703,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -24619,7 +24619,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -25075,7 +25075,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -25990,7 +25990,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -26446,7 +26446,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -26898,7 +26898,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -27259,7 +27259,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -28084,7 +28084,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -29066,7 +29066,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -29977,7 +29977,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -30839,7 +30839,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -31731,7 +31731,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -32232,7 +32232,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -32572,7 +32572,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -32907,7 +32907,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -38522,7 +38522,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -40081,7 +40081,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -40428,7 +40428,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -41433,7 +41433,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -42082,7 +42082,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -42511,7 +42511,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -42845,7 +42845,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -43185,7 +43185,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -47056,7 +47056,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -49001,7 +49001,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -49508,7 +49508,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -49842,7 +49842,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -50174,7 +50174,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -50975,7 +50975,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -51688,7 +51688,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -52023,7 +52023,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -52359,7 +52359,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -57974,7 +57974,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -60512,7 +60512,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -61211,7 +61211,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -61548,7 +61548,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -61883,7 +61883,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -62221,7 +62221,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -62555,7 +62555,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -62889,7 +62889,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -63223,7 +63223,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -63555,7 +63555,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -63853,7 +63853,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -64188,7 +64188,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -65195,7 +65195,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -66005,7 +66005,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -66805,7 +66805,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -72531,7 +72531,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -74092,7 +74092,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -79707,7 +79707,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -81724,7 +81724,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -82609,7 +82609,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -84292,7 +84292,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -84992,7 +84992,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -85326,7 +85326,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -86852,7 +86852,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -87369,7 +87369,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -92984,7 +92984,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -94761,7 +94761,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -95193,7 +95193,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -95527,7 +95527,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -96077,7 +96077,7 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -96512,7 +96512,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -96851,7 +96851,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -97188,7 +97188,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -97525,7 +97525,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -97858,7 +97858,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -2344,7 +2344,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#attachment_fromJsonLd(obj, options);
+              v = await this.#attachment_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -2600,7 +2604,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#attribution_fromJsonLd(doc, options);
+            v = await this.#attribution_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -2698,7 +2706,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#attribution_fromJsonLd(obj, options);
+              v = await this.#attribution_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -2917,7 +2929,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#audience_fromJsonLd(doc, options);
+            v = await this.#audience_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -3014,7 +3030,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#audience_fromJsonLd(obj, options);
+              v = await this.#audience_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -3277,7 +3297,11 @@ get contents(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#context_fromJsonLd(obj, options);
+              v = await this.#context_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -3547,7 +3571,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#generator_fromJsonLd(obj, options);
+              v = await this.#generator_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -4469,7 +4497,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#replyTarget_fromJsonLd(doc, options);
+            v = await this.#replyTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -4566,7 +4598,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#replyTarget_fromJsonLd(obj, options);
+              v = await this.#replyTarget_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -4794,7 +4830,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#location_fromJsonLd(doc, options);
+            v = await this.#location_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -4891,7 +4931,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#location_fromJsonLd(obj, options);
+              v = await this.#location_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -5118,7 +5162,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#preview_fromJsonLd(doc, options);
+            v = await this.#preview_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5214,7 +5262,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -5446,7 +5498,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#replies_fromJsonLd(doc, options);
+            v = await this.#replies_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5670,7 +5726,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#shares_fromJsonLd(doc, options);
+            v = await this.#shares_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5894,7 +5954,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likes_fromJsonLd(doc, options);
+            v = await this.#likes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6112,7 +6176,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#emojiReactions_fromJsonLd(doc, options);
+            v = await this.#emojiReactions_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6382,7 +6450,11 @@ get summaries(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#tag_fromJsonLd(obj, options);
+              v = await this.#tag_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -6635,7 +6707,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#to_fromJsonLd(doc, options);
+            v = await this.#to_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6732,7 +6808,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#to_fromJsonLd(obj, options);
+              v = await this.#to_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -6951,7 +7031,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#bto_fromJsonLd(doc, options);
+            v = await this.#bto_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7048,7 +7132,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#bto_fromJsonLd(obj, options);
+              v = await this.#bto_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7267,7 +7355,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#cc_fromJsonLd(doc, options);
+            v = await this.#cc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7364,7 +7456,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#cc_fromJsonLd(obj, options);
+              v = await this.#cc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7583,7 +7679,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#bcc_fromJsonLd(doc, options);
+            v = await this.#bcc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7680,7 +7780,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#bcc_fromJsonLd(obj, options);
+              v = await this.#bcc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7962,7 +8066,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#proof_fromJsonLd(doc, options);
+            v = await this.#proof_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8058,7 +8166,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#proof_fromJsonLd(obj, options);
+              v = await this.#proof_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -8316,7 +8428,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+            v = await this.#likeAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8534,7 +8650,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+            v = await this.#replyAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8752,7 +8872,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+            v = await this.#announceAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -10301,8 +10425,8 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -13149,8 +13273,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -13587,7 +13711,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -13828,7 +13956,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -14151,8 +14283,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -15216,7 +15348,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#actor_fromJsonLd(doc, options);
+            v = await this.#actor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15314,7 +15450,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#actor_fromJsonLd(obj, options);
+              v = await this.#actor_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -15534,7 +15674,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15632,7 +15776,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -15855,7 +16003,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#target_fromJsonLd(doc, options);
+            v = await this.#target_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15956,7 +16108,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#target_fromJsonLd(obj, options);
+              v = await this.#target_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16176,7 +16332,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#result_fromJsonLd(doc, options);
+            v = await this.#result_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16274,7 +16434,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#result_fromJsonLd(obj, options);
+              v = await this.#result_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16495,7 +16659,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#origin_fromJsonLd(doc, options);
+            v = await this.#origin_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16594,7 +16762,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#origin_fromJsonLd(obj, options);
+              v = await this.#origin_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16813,7 +16985,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#instrument_fromJsonLd(doc, options);
+            v = await this.#instrument_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16910,7 +17086,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#instrument_fromJsonLd(obj, options);
+              v = await this.#instrument_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -17192,8 +17372,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -18075,8 +18255,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -18585,8 +18765,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -19178,8 +19358,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -19678,7 +19858,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -19895,7 +20079,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -20173,8 +20361,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -20630,8 +20818,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -21228,8 +21416,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -21999,8 +22187,8 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -22556,7 +22744,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -22773,7 +22965,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -23051,8 +23247,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -23507,8 +23703,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -23920,7 +24116,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -24137,7 +24337,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -24415,8 +24619,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -24871,8 +25075,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -25283,7 +25487,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -25500,7 +25708,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -25778,8 +25990,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -26234,8 +26446,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -26686,8 +26898,8 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -27047,8 +27259,8 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -27872,8 +28084,8 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -28574,7 +28786,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#owner_fromJsonLd(doc, options);
+            v = await this.#owner_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -28850,8 +29066,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -29474,7 +29690,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#controller_fromJsonLd(doc, options);
+            v = await this.#controller_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -29757,8 +29977,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -30619,8 +30839,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -31511,8 +31731,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -32012,8 +32232,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -32352,8 +32572,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -32687,8 +32907,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -33964,7 +34184,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34059,7 +34283,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -34280,7 +34508,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34379,7 +34611,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -34637,7 +34873,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34872,7 +35112,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35093,7 +35337,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35317,7 +35565,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35539,7 +35791,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35759,7 +36015,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35979,7 +36239,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36197,7 +36461,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -36525,7 +36793,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36781,7 +37053,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36880,7 +37156,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -37101,7 +37381,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -37200,7 +37484,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -38234,8 +38522,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -39793,8 +40081,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -40140,8 +40428,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -40573,7 +40861,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -40814,7 +41106,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -41137,8 +41433,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -41786,8 +42082,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -42215,8 +42511,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -42549,8 +42845,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -42889,8 +43185,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -43645,7 +43941,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#current_fromJsonLd(doc, options);
+            v = await this.#current_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -43863,7 +44163,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#first_fromJsonLd(doc, options);
+            v = await this.#first_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44081,7 +44385,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#last_fromJsonLd(doc, options);
+            v = await this.#last_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44309,7 +44617,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -44527,7 +44839,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likesOf_fromJsonLd(doc, options);
+            v = await this.#likesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44744,7 +45060,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#sharesOf_fromJsonLd(doc, options);
+            v = await this.#sharesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44961,7 +45281,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#repliesOf_fromJsonLd(doc, options);
+            v = await this.#repliesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45178,7 +45502,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inboxOf_fromJsonLd(doc, options);
+            v = await this.#inboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45395,7 +45723,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outboxOf_fromJsonLd(doc, options);
+            v = await this.#outboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45612,7 +45944,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followersOf_fromJsonLd(doc, options);
+            v = await this.#followersOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45829,7 +46165,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followingOf_fromJsonLd(doc, options);
+            v = await this.#followingOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -46046,7 +46386,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likedOf_fromJsonLd(doc, options);
+            v = await this.#likedOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -46712,8 +47056,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -47899,7 +48243,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#partOf_fromJsonLd(doc, options);
+            v = await this.#partOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48115,7 +48463,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#next_fromJsonLd(doc, options);
+            v = await this.#next_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48332,7 +48684,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#prev_fromJsonLd(doc, options);
+            v = await this.#prev_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48645,8 +49001,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -49152,8 +49508,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -49486,8 +49842,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -49818,8 +50174,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -50619,8 +50975,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -51332,8 +51688,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -51667,8 +52023,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -52003,8 +52359,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -53280,7 +53636,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -53375,7 +53735,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -53596,7 +53960,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -53695,7 +54063,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -53953,7 +54325,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54188,7 +54564,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54409,7 +54789,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54633,7 +55017,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54855,7 +55243,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55075,7 +55467,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55295,7 +55691,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55513,7 +55913,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -55841,7 +56245,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56097,7 +56505,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56196,7 +56608,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -56417,7 +56833,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56516,7 +56936,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -57550,8 +57974,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -59629,7 +60053,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -60084,8 +60512,8 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -60783,8 +61211,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -61120,8 +61548,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -61455,8 +61883,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -61793,8 +62221,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -62127,8 +62555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -62461,8 +62889,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -62795,8 +63223,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -63127,8 +63555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -63425,8 +63853,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -63760,8 +64188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -64195,7 +64623,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -64436,7 +64868,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -64759,8 +65195,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -65320,7 +65756,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -65565,8 +66005,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -66067,7 +66507,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -66361,8 +66805,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -67749,7 +68193,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -67844,7 +68292,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -68065,7 +68517,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68164,7 +68620,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -68422,7 +68882,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68657,7 +69121,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68878,7 +69346,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69102,7 +69574,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69324,7 +69800,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69544,7 +70024,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69764,7 +70248,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69982,7 +70470,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -70310,7 +70802,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70566,7 +71062,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70665,7 +71165,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -70886,7 +71390,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70985,7 +71493,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -72019,8 +72531,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -73580,8 +74092,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -74857,7 +75369,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -74952,7 +75468,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -75173,7 +75693,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75272,7 +75796,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -75530,7 +76058,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75765,7 +76297,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75986,7 +76522,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76210,7 +76750,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76432,7 +76976,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76652,7 +77200,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76872,7 +77424,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77090,7 +77646,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -77418,7 +77978,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77674,7 +78238,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77773,7 +78341,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -77994,7 +78566,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -78093,7 +78669,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -79127,8 +79707,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -81144,8 +81724,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -81782,7 +82362,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#describes_fromJsonLd(doc, options);
+            v = await this.#describes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -82025,8 +82609,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -82674,7 +83258,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+              v = await this.#exclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -82895,7 +83483,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+              v = await this.#inclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -83145,7 +83737,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -83386,7 +83982,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -83692,8 +84292,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -84392,8 +84992,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -84726,8 +85326,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -85287,7 +85887,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#subject_fromJsonLd(doc, options);
+            v = await this.#subject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85504,7 +86108,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85600,7 +86208,11 @@ relationships?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -85820,7 +86432,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#relationship_fromJsonLd(doc, options);
+            v = await this.#relationship_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85918,7 +86534,11 @@ relationships?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#relationship_fromJsonLd(obj, options);
+              v = await this.#relationship_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -86232,8 +86852,8 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -86749,8 +87369,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -88026,7 +88646,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88121,7 +88745,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -88342,7 +88970,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88441,7 +89073,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -88699,7 +89335,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88934,7 +89574,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89155,7 +89799,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89379,7 +90027,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89601,7 +90253,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89821,7 +90477,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90041,7 +90701,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90259,7 +90923,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -90587,7 +91255,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90843,7 +91515,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90942,7 +91618,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -91163,7 +91843,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -91262,7 +91946,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -92296,8 +92984,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -94073,8 +94761,8 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -94505,8 +95193,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -94839,8 +95527,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -95389,8 +96077,8 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -95824,8 +96512,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -96163,8 +96851,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -96500,8 +97188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -96837,8 +97525,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -97170,8 +97858,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -48,6 +48,7 @@ export class Object {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -76,6 +77,10 @@ export class Object {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -205,6 +210,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -3784,7 +3791,7 @@ get names(): ((string | LanguageString))[] {
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       
           }
@@ -3886,7 +3893,7 @@ get names(): ((string | LanguageString))[] {
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       
             }
@@ -4131,7 +4138,7 @@ get names(): ((string | LanguageString))[] {
             v = await this.#image_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       
           }
@@ -4233,7 +4240,7 @@ get names(): ((string | LanguageString))[] {
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       
             }
@@ -18148,6 +18155,7 @@ export class PropertyValue {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18176,6 +18184,10 @@ export class PropertyValue {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -18208,6 +18220,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -18749,6 +18763,7 @@ export class Measure {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18777,6 +18792,10 @@ export class Measure {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -18809,6 +18828,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -20696,6 +20717,7 @@ export class InteractionPolicy {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -20724,6 +20746,10 @@ export class InteractionPolicy {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -20758,6 +20784,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -21488,6 +21516,7 @@ export class InteractionRule {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -21516,6 +21545,10 @@ export class InteractionRule {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -21550,6 +21583,8 @@ manualApprovals?: (URL)[];}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -26283,6 +26318,7 @@ export class DidService {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -26311,6 +26347,10 @@ export class DidService {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -26343,6 +26383,8 @@ endpoints?: (URL)[];}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -27087,6 +27129,7 @@ export class DataIntegrityProof {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -27115,6 +27158,10 @@ export class DataIntegrityProof {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -27152,6 +27199,8 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -28126,6 +28175,7 @@ export class CryptographicKey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -28154,6 +28204,10 @@ export class CryptographicKey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -28188,6 +28242,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -29019,6 +29075,7 @@ export class Multikey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -29047,6 +29104,10 @@ export class Multikey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -29081,6 +29142,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -29917,6 +29980,7 @@ export class Intent {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -29945,6 +30009,10 @@ export class Intent {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -29980,6 +30048,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -49828,6 +49898,7 @@ export class Endpoints {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -49856,6 +49927,10 @@ export class Endpoints {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -49892,6 +49967,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -58785,6 +58862,7 @@ export class Link {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -58813,6 +58891,10 @@ export class Link {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -58855,6 +58937,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];
@@ -93516,6 +93600,7 @@ export class Source {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -93544,6 +93629,10 @@ export class Source {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -93577,6 +93666,8 @@ contents?: ((string | LanguageString))[];mediaType?: string | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"\$warning\\" in options) {
       this.#warning = options.\$warning as unknown as {
         category: string[];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10569,7 +10569,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -18601,7 +18601,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19194,7 +19194,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -21244,7 +21244,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -22015,7 +22015,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -26706,7 +26706,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -27888,7 +27888,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28866,7 +28866,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -29773,7 +29773,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -30635,7 +30635,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -50635,7 +50635,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -60108,7 +60108,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -94089,7 +94089,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10617,7 +10617,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     
@@ -18471,7 +18471,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19062,7 +19062,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -21116,7 +21116,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21869,7 +21869,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -26560,7 +26560,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -27737,7 +27737,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28711,7 +28711,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     
@@ -29598,7 +29598,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     
@@ -30438,7 +30438,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -50393,7 +50393,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -59776,7 +59776,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -93637,7 +93637,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -2336,11 +2336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attachment\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attachment_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#attachment_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -2594,11 +2592,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"attributedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#attribution_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#attribution_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -2694,11 +2690,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attributedTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attribution_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#attribution_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -2915,11 +2909,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"audience\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#audience_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#audience_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -3014,11 +3006,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"audience\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#audience_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#audience_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3279,11 +3269,9 @@ get contents(): ((string | LanguageString))[] {
               \\"context\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#context_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#context_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3551,11 +3539,9 @@ get names(): ((string | LanguageString))[] {
               \\"generator\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#generator_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#generator_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3792,11 +3778,13 @@ get names(): ((string | LanguageString))[] {
             \\"icon\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
+      
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      
           }
         }
         
@@ -3892,11 +3880,13 @@ get names(): ((string | LanguageString))[] {
               \\"icon\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
+      
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      
             }
           }
         
@@ -4133,11 +4123,13 @@ get names(): ((string | LanguageString))[] {
             \\"image\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
+      
             v = await this.#image_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      
           }
         }
         
@@ -4233,11 +4225,13 @@ get names(): ((string | LanguageString))[] {
               \\"image\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
+      
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      
             }
           }
         
@@ -4463,11 +4457,9 @@ get names(): ((string | LanguageString))[] {
             \\"inReplyTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replyTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -4562,11 +4554,9 @@ get names(): ((string | LanguageString))[] {
               \\"inReplyTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#replyTarget_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#replyTarget_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -4792,11 +4782,9 @@ get names(): ((string | LanguageString))[] {
             \\"location\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#location_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#location_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -4891,11 +4879,9 @@ get names(): ((string | LanguageString))[] {
               \\"location\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#location_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#location_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -5120,11 +5106,9 @@ get names(): ((string | LanguageString))[] {
             \\"preview\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#preview_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#preview_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5218,11 +5202,9 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#preview_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -5452,11 +5434,9 @@ get names(): ((string | LanguageString))[] {
             \\"replies\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replies_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replies_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5678,11 +5658,9 @@ get names(): ((string | LanguageString))[] {
             \\"shares\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#shares_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#shares_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5904,11 +5882,9 @@ get names(): ((string | LanguageString))[] {
             \\"likes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likes_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likes_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6124,11 +6100,9 @@ get names(): ((string | LanguageString))[] {
             \\"emojiReactions\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#emojiReactions_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#emojiReactions_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6396,11 +6370,9 @@ get summaries(): ((string | LanguageString))[] {
               \\"tag\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#tag_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#tag_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -6651,11 +6623,9 @@ get urls(): ((URL | Link))[] {
             \\"to\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#to_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#to_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6750,11 +6720,9 @@ get urls(): ((URL | Link))[] {
               \\"to\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#to_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#to_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -6971,11 +6939,9 @@ get urls(): ((URL | Link))[] {
             \\"bto\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bto_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#bto_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7070,11 +7036,9 @@ get urls(): ((URL | Link))[] {
               \\"bto\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bto_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#bto_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7291,11 +7255,9 @@ get urls(): ((URL | Link))[] {
             \\"cc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#cc_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#cc_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7390,11 +7352,9 @@ get urls(): ((URL | Link))[] {
               \\"cc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#cc_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#cc_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7611,11 +7571,9 @@ get urls(): ((URL | Link))[] {
             \\"bcc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bcc_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#bcc_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7710,11 +7668,9 @@ get urls(): ((URL | Link))[] {
               \\"bcc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bcc_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#bcc_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7994,11 +7950,9 @@ get urls(): ((URL | Link))[] {
             \\"proof\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#proof_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#proof_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8092,11 +8046,9 @@ get urls(): ((URL | Link))[] {
               \\"proof\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#proof_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#proof_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -8352,11 +8304,9 @@ get urls(): ((URL | Link))[] {
             \\"likeAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likeAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8572,11 +8522,9 @@ get urls(): ((URL | Link))[] {
             \\"replyAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8792,11 +8740,9 @@ get urls(): ((URL | Link))[] {
             \\"announceAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#announceAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -10344,14 +10290,9 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -10650,16 +10591,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10696,23 +10637,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10747,7 +10688,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10807,12 +10748,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10896,12 +10837,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10932,7 +10873,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: _baseUrl,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10958,7 +10899,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10987,7 +10928,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: _baseUrl,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11013,7 +10954,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11049,12 +10990,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11092,12 +11033,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11135,12 +11076,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11197,7 +11138,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11230,7 +11171,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11263,7 +11204,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11296,7 +11237,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11378,12 +11319,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11442,13 +11383,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11483,7 +11424,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11516,7 +11457,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11549,7 +11490,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11582,7 +11523,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11657,7 +11598,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11690,7 +11631,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11711,7 +11652,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11743,9 +11684,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11777,7 +11718,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11810,7 +11751,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11843,7 +11784,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13021,14 +12962,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -13463,11 +13399,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -13706,11 +13640,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -14032,14 +13964,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -14088,7 +14015,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14147,7 +14074,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -15093,11 +15020,9 @@ instruments?: (Object | URL)[];}
             \\"actor\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#actor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#actor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15193,11 +15118,9 @@ instruments?: (Object | URL)[];}
               \\"actor\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#actor_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#actor_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -15415,11 +15338,9 @@ instruments?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#object_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15515,11 +15436,9 @@ instruments?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#object_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -15740,11 +15659,9 @@ instruments?: (Object | URL)[];}
             \\"target\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#target_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#target_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15843,11 +15760,9 @@ instruments?: (Object | URL)[];}
               \\"target\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#target_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#target_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16065,11 +15980,9 @@ instruments?: (Object | URL)[];}
             \\"result\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#result_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#result_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16165,11 +16078,9 @@ instruments?: (Object | URL)[];}
               \\"result\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#result_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#result_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16388,11 +16299,9 @@ instruments?: (Object | URL)[];}
             \\"origin\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#origin_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#origin_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16489,11 +16398,9 @@ instruments?: (Object | URL)[];}
               \\"origin\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#origin_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#origin_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16710,11 +16617,9 @@ instruments?: (Object | URL)[];}
             \\"instrument\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#instrument_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#instrument_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16809,11 +16714,9 @@ instruments?: (Object | URL)[];}
               \\"instrument\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#instrument_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#instrument_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -17094,14 +16997,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -17288,23 +17186,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17339,7 +17237,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17372,7 +17270,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17405,7 +17303,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17438,7 +17336,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17471,7 +17369,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17942,14 +17840,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -18450,14 +18343,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -19041,14 +18929,9 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -19545,11 +19428,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -19764,11 +19645,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -20045,14 +19924,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -20101,7 +19975,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20134,7 +20008,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20499,14 +20373,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21095,14 +20964,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21134,7 +20998,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21155,7 +21019,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21176,7 +21040,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21197,7 +21061,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21848,14 +21712,9 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21898,9 +21757,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21931,9 +21790,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22393,11 +22252,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -22612,11 +22469,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -22893,14 +22748,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -22949,7 +22799,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22982,7 +22832,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23346,14 +23196,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -23763,11 +23608,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -23982,11 +23825,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -24263,14 +24104,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -24319,7 +24155,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24352,7 +24188,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24716,14 +24552,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25132,11 +24963,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -25351,11 +25180,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -25632,14 +25459,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25688,7 +25510,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25721,7 +25543,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26085,14 +25907,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26535,14 +26352,9 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26589,9 +26401,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26893,14 +26705,9 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27716,14 +27523,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27785,7 +27587,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28411,11 +28213,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
             \\"owner\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#owner_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#owner_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -28690,14 +28490,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -28743,23 +28538,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29291,11 +29086,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
             \\"controller\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#controller_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#controller_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -29577,14 +29370,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -29630,23 +29418,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30417,14 +30205,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -30485,9 +30268,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30507,7 +30290,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30528,7 +30311,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30549,7 +30332,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31294,14 +31077,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -31356,7 +31134,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31377,7 +31155,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31792,14 +31570,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32137,14 +31910,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32477,14 +32245,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -33758,11 +33521,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -33855,11 +33616,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -34078,11 +33837,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34179,11 +33936,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -34439,11 +34194,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34676,11 +34429,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34899,11 +34650,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35125,11 +34874,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35349,11 +35096,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35571,11 +35316,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35793,11 +35536,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36013,11 +35754,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -36343,11 +36082,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36601,11 +36338,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36702,11 +36437,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -36925,11 +36658,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -37026,11 +36757,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -38063,14 +37792,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -38143,7 +37867,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38176,7 +37900,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38229,11 +37953,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38270,11 +37994,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38309,7 +38033,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38342,7 +38066,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38375,7 +38099,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38408,7 +38132,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38441,7 +38165,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38474,7 +38198,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38495,7 +38219,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38602,23 +38326,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38655,23 +38379,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38706,7 +38430,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39531,14 +39255,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -39883,14 +39602,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40320,11 +40034,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -40563,11 +40275,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -40889,14 +40599,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40945,7 +40650,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -41004,7 +40709,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41535,14 +41240,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -41969,14 +41669,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42308,14 +42003,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42653,14 +42343,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -43413,11 +43098,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"current\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#current_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#current_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -43633,11 +43316,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"first\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#first_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#first_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -43853,11 +43534,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"last\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#last_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#last_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44083,11 +43762,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"items\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -44303,11 +43980,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44522,11 +44197,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"sharesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#sharesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#sharesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44741,11 +44414,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"repliesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#repliesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#repliesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44960,11 +44631,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"inboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inboxOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inboxOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45179,11 +44848,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"outboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outboxOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outboxOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45398,11 +45065,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followersOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followersOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followersOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45617,11 +45282,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followingOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followingOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followingOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45836,11 +45499,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likedOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likedOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likedOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -46505,14 +46166,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -46591,7 +46247,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46624,7 +46280,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46657,7 +46313,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46693,12 +46349,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46733,7 +46389,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46766,7 +46422,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46799,7 +46455,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46832,7 +46488,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46865,7 +46521,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46898,7 +46554,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46931,7 +46587,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46964,7 +46620,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47644,11 +47300,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"partOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#partOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#partOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -47862,11 +47516,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"next\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#next_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#next_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -48081,11 +47733,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"prev\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#prev_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#prev_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -48397,14 +48047,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -48457,7 +48102,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48490,7 +48135,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48523,7 +48168,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48897,14 +48542,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49236,14 +48876,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49573,14 +49208,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50372,14 +50002,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50422,9 +50047,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50455,9 +50080,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50488,9 +50113,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50521,9 +50146,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50554,9 +50179,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50587,9 +50212,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -51042,14 +50667,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51382,14 +51002,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51723,14 +51338,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -53004,11 +52614,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53101,11 +52709,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -53324,11 +52930,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53425,11 +53029,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -53685,11 +53287,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53922,11 +53522,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54145,11 +53743,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54371,11 +53967,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54595,11 +54189,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54817,11 +54409,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55039,11 +54629,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55259,11 +54847,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -55589,11 +55175,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55847,11 +55431,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55948,11 +55530,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -56171,11 +55751,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -56272,11 +55850,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -57309,14 +56885,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -57389,7 +56960,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57422,7 +56993,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57475,11 +57046,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57516,11 +57087,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57555,7 +57126,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57588,7 +57159,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57621,7 +57192,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57654,7 +57225,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57687,7 +57258,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57720,7 +57291,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57741,7 +57312,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57848,23 +57419,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57901,23 +57472,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57952,7 +57523,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59289,11 +58860,9 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#preview_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -59747,14 +59316,9 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -59805,9 +59369,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59956,12 +59520,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60435,14 +59999,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -60777,14 +60336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61117,14 +60671,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61460,14 +61009,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61799,14 +61343,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62138,14 +61677,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62477,14 +62011,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62814,14 +62343,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63117,14 +62641,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63457,14 +62976,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63896,11 +63410,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -64139,11 +63651,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -64465,14 +63975,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -64521,7 +64026,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64580,7 +64085,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -65022,11 +64527,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -65270,14 +64773,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -65329,12 +64827,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65768,11 +65266,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -66065,14 +65561,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -66124,12 +65615,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -67449,11 +66940,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -67546,11 +67035,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -67769,11 +67256,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -67870,11 +67355,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -68130,11 +67613,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68367,11 +67848,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68590,11 +68069,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68816,11 +68293,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69040,11 +68515,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69262,11 +68735,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69484,11 +68955,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69704,11 +69173,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -70034,11 +69501,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70292,11 +69757,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70393,11 +69856,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -70616,11 +70077,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70717,11 +70176,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -71754,14 +71211,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -71834,7 +71286,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71867,7 +71319,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71920,11 +71372,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71961,11 +71413,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72000,7 +71452,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -72033,7 +71485,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -72066,7 +71518,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -72099,7 +71551,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -72132,7 +71584,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -72165,7 +71617,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -72186,7 +71638,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -72293,23 +71745,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72346,23 +71798,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72397,7 +71849,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -73224,14 +72676,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -74505,11 +73952,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -74602,11 +74047,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -74825,11 +74268,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -74926,11 +74367,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -75186,11 +74625,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75423,11 +74860,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75646,11 +75081,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75872,11 +75305,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76096,11 +75527,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76318,11 +75747,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76540,11 +75967,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76760,11 +76185,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -77090,11 +76513,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77348,11 +76769,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77449,11 +76868,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -77672,11 +77089,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77773,11 +77188,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -78810,14 +78223,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -78890,7 +78298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78923,7 +78331,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78976,11 +78384,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79017,11 +78425,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79056,7 +78464,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -79089,7 +78497,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -79122,7 +78530,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -79155,7 +78563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -79188,7 +78596,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -79221,7 +78629,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -79242,7 +78650,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79349,23 +78757,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79402,23 +78810,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79453,7 +78861,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80736,14 +80144,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -80885,9 +80288,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81370,11 +80773,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"describes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#describes_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#describes_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -81616,14 +81017,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -81672,7 +81068,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82265,11 +81661,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"oneOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#exclusiveOption_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -82488,11 +81882,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"anyOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#inclusiveOption_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -82740,11 +82132,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -82983,11 +82373,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -83292,14 +82680,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -83348,7 +82731,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83381,7 +82764,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83463,7 +82846,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83522,7 +82905,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83981,14 +83364,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -84320,14 +83698,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -84885,11 +84258,9 @@ relationships?: (Object | URL)[];}
             \\"subject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#subject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#subject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85104,11 +84475,9 @@ relationships?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#object_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85202,11 +84571,9 @@ relationships?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#object_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -85424,11 +84791,9 @@ relationships?: (Object | URL)[];}
             \\"relationship\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#relationship_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#relationship_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85524,11 +84889,9 @@ relationships?: (Object | URL)[];}
               \\"relationship\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#relationship_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#relationship_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -85841,14 +85204,9 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -85897,7 +85255,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85930,7 +85288,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85963,7 +85321,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86351,14 +85709,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -87632,11 +86985,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -87729,11 +87080,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -87952,11 +87301,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88053,11 +87400,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -88313,11 +87658,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88550,11 +87893,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88773,11 +88114,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88999,11 +88338,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89223,11 +88560,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89445,11 +88780,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89667,11 +89000,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89887,11 +89218,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -90217,11 +89546,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90475,11 +89802,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90576,11 +89901,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -90799,11 +90122,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90900,11 +90221,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -91937,14 +91256,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -92017,7 +91331,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -92050,7 +91364,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -92103,11 +91417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92144,11 +91458,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92183,7 +91497,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -92216,7 +91530,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -92249,7 +91563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -92282,7 +91596,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -92315,7 +91629,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -92348,7 +91662,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92369,7 +91683,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92476,23 +91790,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92529,23 +91843,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92580,7 +91894,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93616,14 +92930,9 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94053,14 +93362,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94392,14 +93696,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94947,14 +94246,9 @@ get formerTypes(): (\$EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95387,14 +94681,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95731,14 +95020,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96073,14 +95357,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96415,14 +95694,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96753,14 +96027,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10892,27 +10892,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -10922,43 +10904,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10984,27 +10939,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11013,68 +10950,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11100,43 +10992,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -11184,27 +11049,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11214,30 +11061,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11309,27 +11138,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11339,30 +11150,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11393,16 +11186,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })(),
+            baseUrl: options.baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11419,43 +11203,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11484,16 +11241,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })(),
+            baseUrl: options.baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11510,43 +11258,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11570,27 +11291,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11600,30 +11303,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11649,27 +11334,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11679,30 +11346,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11728,27 +11377,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11758,30 +11389,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11829,43 +11442,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11889,43 +11475,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11949,43 +11508,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -12009,43 +11541,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -12115,27 +11620,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -12145,30 +11632,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -12227,40 +11696,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], options.baseUrl) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -12286,43 +11728,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -12346,43 +11761,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -12406,43 +11794,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -12466,43 +11827,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -12577,16 +11911,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -12610,43 +11935,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -12667,16 +11965,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -12708,27 +11997,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12751,43 +12022,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12811,43 +12055,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12871,43 +12088,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -15153,43 +14343,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -15239,43 +14402,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -18487,27 +17623,9 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -18516,68 +17634,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -18603,43 +17676,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -18663,43 +17709,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -18723,43 +17742,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -18783,43 +17775,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -18843,43 +17808,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -21520,43 +20458,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -21580,43 +20491,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -22619,16 +21503,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -22649,16 +21524,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -22679,16 +21545,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -22709,16 +21566,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -23424,27 +22272,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -23475,27 +22305,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -24514,43 +23326,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24574,43 +23359,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25948,43 +24706,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26008,43 +24739,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -27381,43 +26085,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -27441,43 +26118,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -28348,27 +26998,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -29556,43 +28188,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -30551,27 +29156,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -30580,68 +29167,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -31513,27 +30055,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -31542,68 +30066,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -32447,27 +30926,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -32487,16 +30948,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -32517,16 +30969,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -32547,16 +30990,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -33361,16 +31795,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -33391,16 +31816,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -40268,43 +38684,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -40328,43 +38717,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -40406,27 +38768,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -40435,29 +38779,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -40483,27 +38809,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -40512,29 +38820,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -40560,43 +38850,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -40620,43 +38883,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -40680,43 +38916,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -40740,43 +38949,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -40800,43 +38982,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -40860,43 +39015,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -40917,16 +39045,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -41022,27 +39141,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -41051,68 +39152,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -41138,27 +39194,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -41167,68 +39205,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -41254,43 +39247,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -43528,43 +41494,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -43614,43 +41553,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -49302,43 +47214,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -49362,43 +47247,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -49422,43 +47280,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -49482,27 +47313,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -49512,30 +47325,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -49561,43 +47356,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -49621,43 +47389,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -49681,43 +47422,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -49741,43 +47455,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -49801,43 +47488,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -49861,43 +47521,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -49921,43 +47554,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -49981,43 +47587,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -51520,43 +49099,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -51580,43 +49132,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -51640,43 +49165,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -53574,27 +51072,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -53625,27 +51105,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -53676,27 +51138,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -53727,27 +51171,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -53778,27 +51204,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -53829,27 +51237,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -60751,43 +58141,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -60811,43 +58174,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -60889,27 +58225,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -60918,29 +58236,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60966,27 +58266,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -60995,29 +58277,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61043,43 +58307,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -61103,43 +58340,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -61163,43 +58373,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -61223,43 +58406,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -61283,43 +58439,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -61343,43 +58472,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -61400,16 +58502,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -61505,27 +58598,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -61534,68 +58609,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61621,27 +58651,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -61650,68 +58662,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61737,43 +58704,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -63638,27 +60578,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -63795,27 +60717,9 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -63825,30 +60729,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -68391,43 +65277,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -68477,43 +65336,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -69255,27 +66087,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -69285,30 +66099,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -70091,27 +66887,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -70121,30 +66899,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -75957,43 +72717,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -76017,43 +72750,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -76095,27 +72801,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76124,29 +72812,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76172,27 +72842,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76201,29 +72853,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76249,43 +72883,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -76309,43 +72916,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -76369,43 +72949,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -76429,43 +72982,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -76489,43 +73015,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -76549,43 +73048,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -76606,16 +73078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -76711,27 +73174,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76740,68 +73185,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76827,27 +73227,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76856,68 +73238,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76943,43 +73280,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -83578,43 +79888,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -83638,43 +79921,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -83716,27 +79972,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -83745,29 +79983,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -83793,27 +80013,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -83822,29 +80024,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -83870,43 +80054,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -83930,43 +80087,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -83990,43 +80120,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -84050,43 +80153,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -84110,43 +80186,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -84170,43 +80219,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -84227,16 +80249,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -84332,27 +80345,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -84361,68 +80356,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -84448,27 +80398,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -84477,68 +80409,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -84564,43 +80451,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -86030,27 +81890,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) : undefined
+          : new URL(v[\\"@id\\"], options.baseUrl) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -86831,43 +82673,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -88560,43 +84375,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -88620,43 +84408,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -88729,43 +84490,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -88815,43 +84549,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -91246,43 +86953,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -91306,43 +86986,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -91366,43 +87019,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -97562,43 +93188,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -97622,43 +93221,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -97700,27 +93272,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -97729,29 +93283,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -97777,27 +93313,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -97806,29 +93324,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -97854,43 +93354,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -97914,43 +93387,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -97974,43 +93420,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -98034,43 +93453,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -98094,43 +93486,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -98154,43 +93519,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -98211,16 +93549,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -98316,27 +93645,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -98345,68 +93656,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -98432,27 +93698,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -98461,68 +93709,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -98548,43 +93751,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -10595,16 +10595,28 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10641,23 +10653,43 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10692,7 +10724,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10752,12 +10788,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10841,12 +10885,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10877,7 +10929,11 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10903,7 +10959,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10932,7 +10992,11 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10958,7 +11022,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10994,12 +11062,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11037,12 +11113,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11080,12 +11164,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11142,7 +11234,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11175,7 +11271,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11208,7 +11308,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11241,7 +11345,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11323,12 +11431,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11387,13 +11503,25 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11428,7 +11556,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11461,7 +11593,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11494,7 +11630,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11527,7 +11667,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11602,7 +11746,11 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11635,7 +11783,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11656,7 +11808,11 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11688,9 +11844,17 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11722,7 +11886,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11755,7 +11923,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11788,7 +11960,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -14019,7 +14195,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14078,7 +14258,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17190,23 +17374,43 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17241,7 +17445,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17274,7 +17482,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17307,7 +17519,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17340,7 +17556,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17373,7 +17593,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19979,7 +20203,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20012,7 +20240,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -21002,7 +21234,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21023,7 +21259,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21044,7 +21284,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21065,7 +21309,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21761,9 +22009,17 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21794,9 +22050,17 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22803,7 +23067,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22836,7 +23104,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24159,7 +24431,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24192,7 +24468,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25514,7 +25794,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25547,7 +25831,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26405,9 +26693,17 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27591,7 +27887,11 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28542,23 +28842,43 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29422,23 +29742,43 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30272,9 +30612,17 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30294,7 +30642,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30315,7 +30667,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30336,7 +30692,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31138,7 +31498,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31159,7 +31523,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37871,7 +38239,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37904,7 +38276,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37957,11 +38333,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37998,11 +38382,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38037,7 +38429,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38070,7 +38466,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38103,7 +38503,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38136,7 +38540,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38169,7 +38577,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38202,7 +38614,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38223,7 +38639,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38330,23 +38750,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38383,23 +38823,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38434,7 +38894,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40654,7 +41118,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40713,7 +41181,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46251,7 +46723,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46284,7 +46760,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46317,7 +46797,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46353,12 +46837,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46393,7 +46885,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46426,7 +46922,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46459,7 +46959,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46492,7 +46996,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46525,7 +47033,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46558,7 +47070,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46591,7 +47107,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46624,7 +47144,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48106,7 +48630,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48139,7 +48667,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48172,7 +48704,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -50051,9 +50587,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50084,9 +50628,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50117,9 +50669,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50150,9 +50710,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50183,9 +50751,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50216,9 +50792,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56964,7 +57548,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56997,7 +57585,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57050,11 +57642,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57091,11 +57691,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57130,7 +57738,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57163,7 +57775,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57196,7 +57812,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57229,7 +57849,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57262,7 +57886,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57295,7 +57923,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57316,7 +57948,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57423,23 +58059,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57476,23 +58132,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57527,7 +58203,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59373,9 +60053,17 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59524,12 +60212,20 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -64030,7 +64726,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64089,7 +64789,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64831,12 +65535,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65619,12 +66331,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71290,7 +72010,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71323,7 +72047,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71376,11 +72104,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71417,11 +72153,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71456,7 +72200,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71489,7 +72237,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71522,7 +72274,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71555,7 +72311,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71588,7 +72348,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71621,7 +72385,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71642,7 +72410,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71749,23 +72521,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71802,23 +72594,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71853,7 +72665,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -78302,7 +79118,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78335,7 +79155,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78388,11 +79212,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78429,11 +79261,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78468,7 +79308,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78501,7 +79345,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78534,7 +79382,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78567,7 +79419,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78600,7 +79456,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78633,7 +79493,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78654,7 +79518,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78761,23 +79629,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78814,23 +79702,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78865,7 +79773,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80292,9 +81204,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81072,7 +81992,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82735,7 +83659,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82768,7 +83696,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82850,7 +83782,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82909,7 +83845,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -85259,7 +86199,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85292,7 +86236,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85325,7 +86273,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -91335,7 +92287,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91368,7 +92324,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91421,11 +92381,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91462,11 +92430,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91501,7 +92477,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91534,7 +92514,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91567,7 +92551,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91600,7 +92588,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91633,7 +92625,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91666,7 +92662,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91687,7 +92687,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91794,23 +92798,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91847,23 +92871,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91898,7 +92942,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -2346,8 +2346,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#attachment_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -2606,8 +2611,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#attribution_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -2708,8 +2718,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#attribution_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -2931,8 +2946,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#audience_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -3032,8 +3052,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#audience_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3299,8 +3324,13 @@ get contents(): ((string | LanguageString))[] {
       
               v = await this.#context_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3573,8 +3603,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#generator_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3818,8 +3853,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -3920,8 +3960,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4165,8 +4210,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#image_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4267,8 +4317,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4499,8 +4554,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#replyTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4600,8 +4660,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#replyTarget_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4832,8 +4897,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#location_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4933,8 +5003,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#location_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -5164,8 +5239,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#preview_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5264,8 +5344,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#preview_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -5500,8 +5585,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#replies_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5728,8 +5818,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#shares_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5956,8 +6051,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#likes_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6178,8 +6278,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#emojiReactions_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6452,8 +6557,13 @@ get summaries(): ((string | LanguageString))[] {
       
               v = await this.#tag_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -6709,8 +6819,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#to_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6810,8 +6925,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#to_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7033,8 +7153,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#bto_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7134,8 +7259,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#bto_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7357,8 +7487,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#cc_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7458,8 +7593,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#cc_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7681,8 +7821,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#bcc_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7782,8 +7927,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#bcc_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -8068,8 +8218,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#proof_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8168,8 +8323,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#proof_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -8430,8 +8590,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#likeAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8652,8 +8817,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#replyAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8874,8 +9044,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#announceAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -10717,17 +10892,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10737,28 +10922,43 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10784,17 +10984,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10803,43 +11013,68 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10865,28 +11100,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10934,17 +11184,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10954,20 +11214,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11039,17 +11309,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11059,20 +11339,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11103,11 +11393,16 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })(),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11124,28 +11419,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11174,11 +11484,16 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })(),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11195,28 +11510,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11240,17 +11570,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11260,20 +11600,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11299,17 +11649,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11319,20 +11679,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11358,17 +11728,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11378,20 +11758,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11439,28 +11829,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11484,28 +11889,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11529,28 +11949,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11574,28 +12009,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11665,17 +12115,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11685,20 +12145,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11757,25 +12227,40 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11801,28 +12286,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11846,28 +12346,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11891,28 +12406,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11936,28 +12466,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -12032,11 +12577,16 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -12060,28 +12610,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -12102,11 +12667,16 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -12138,17 +12708,27 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12171,28 +12751,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12216,28 +12811,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12261,28 +12871,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13903,8 +14528,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -14148,8 +14778,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -14518,28 +15153,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14589,28 +15239,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -15559,8 +16224,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#actor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -15661,8 +16331,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#actor_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -15885,8 +16560,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#object_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -15987,8 +16667,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#object_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16214,8 +16899,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#target_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16319,8 +17009,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#target_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16543,8 +17238,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#result_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16645,8 +17345,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#result_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16870,8 +17575,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#origin_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16973,8 +17683,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#origin_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -17196,8 +17911,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#instrument_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -17297,8 +18017,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#instrument_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -17762,17 +18487,27 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -17781,43 +18516,68 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17843,28 +18603,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17888,28 +18663,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17933,28 +18723,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17978,28 +18783,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -18023,28 +18843,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -20129,8 +20964,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -20350,8 +21190,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -20675,28 +21520,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20720,28 +21580,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -21744,11 +22619,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21769,11 +22649,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21794,11 +22679,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21819,11 +22709,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -22529,17 +23424,27 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -22570,17 +23475,27 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -23043,8 +23958,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -23264,8 +24184,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -23589,28 +24514,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -23634,28 +24574,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24437,8 +25392,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -24658,8 +25618,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -24983,28 +25948,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25028,28 +26008,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25830,8 +26825,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -26051,8 +27051,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -26376,28 +27381,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26421,28 +27441,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -27313,17 +28348,27 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -28511,28 +29556,43 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -29168,8 +30228,13 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       
             v = await this.#owner_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -29486,17 +30551,27 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -29505,43 +30580,68 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30083,8 +31183,13 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       
             v = await this.#controller_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -30408,17 +31513,27 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -30427,43 +31542,68 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -31307,17 +32447,27 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -31337,11 +32487,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -31362,11 +32517,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -31387,11 +32547,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -32196,11 +33361,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -32221,11 +33391,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -34603,8 +35778,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -34702,8 +35882,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -34927,8 +36112,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35030,8 +36220,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -35292,8 +36487,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35531,8 +36731,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35756,8 +36961,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35984,8 +37194,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36210,8 +37425,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36434,8 +37654,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36658,8 +37883,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36880,8 +38110,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -37212,8 +38447,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37472,8 +38712,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37575,8 +38820,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -37800,8 +39050,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37903,8 +39158,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -39008,28 +40268,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -39053,28 +40328,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -39116,17 +40406,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39135,19 +40435,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39173,17 +40483,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39192,19 +40512,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39230,28 +40560,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -39275,28 +40620,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -39320,28 +40680,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -39365,28 +40740,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -39410,28 +40800,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -39455,28 +40860,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -39497,11 +40917,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -39597,17 +41022,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39616,43 +41051,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39678,17 +41138,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39697,43 +41167,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39759,28 +41254,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -41393,8 +42903,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -41638,8 +43153,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -42008,28 +43528,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -42079,28 +43614,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -44504,8 +46054,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#current_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -44726,8 +46281,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#first_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -44948,8 +46508,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#last_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45180,8 +46745,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -45402,8 +46972,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#likesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45623,8 +47198,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#sharesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45844,8 +47424,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#repliesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46065,8 +47650,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#inboxOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46286,8 +47876,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#outboxOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46507,8 +48102,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#followersOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46728,8 +48328,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#followingOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46949,8 +48554,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#likedOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -47692,28 +49302,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -47737,28 +49362,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -47782,28 +49422,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -47827,17 +49482,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -47847,20 +49512,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -47886,28 +49561,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -47931,28 +49621,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -47976,28 +49681,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -48021,28 +49741,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -48066,28 +49801,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -48111,28 +49861,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -48156,28 +49921,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -48201,28 +49981,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48905,8 +50700,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#partOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49125,8 +50925,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#next_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49346,8 +51151,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#prev_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49710,28 +51520,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -49755,28 +51580,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -49800,28 +51640,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -51719,17 +53574,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -51760,17 +53625,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -51801,17 +53676,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -51842,17 +53727,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -51883,17 +53778,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -51924,17 +53829,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -54346,8 +56261,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -54445,8 +56365,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -54670,8 +56595,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -54773,8 +56703,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -55035,8 +56970,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55274,8 +57214,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55499,8 +57444,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55727,8 +57677,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55953,8 +57908,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56177,8 +58137,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56401,8 +58366,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56623,8 +58593,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -56955,8 +58930,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57215,8 +59195,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57318,8 +59303,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -57543,8 +59533,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57646,8 +59641,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -58751,28 +60751,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -58796,28 +60811,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -58859,17 +60889,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -58878,19 +60918,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58916,17 +60966,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -58935,19 +60995,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58973,28 +61043,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -59018,28 +61103,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -59063,28 +61163,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -59108,28 +61223,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -59153,28 +61283,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -59198,28 +61343,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -59240,11 +61400,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -59340,17 +61505,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -59359,43 +61534,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -59421,17 +61621,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -59440,43 +61650,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -59502,28 +61737,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -60870,8 +63120,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#preview_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -61383,17 +63638,27 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -61530,17 +63795,27 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -61550,20 +63825,30 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65481,8 +67766,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -65726,8 +68016,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -66096,28 +68391,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -66167,28 +68477,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -66633,8 +68958,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -66925,17 +69255,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -66945,20 +69285,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -67395,8 +69745,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -67736,17 +70091,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -67756,20 +70121,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -69092,8 +71467,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -69191,8 +71571,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -69416,8 +71801,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -69519,8 +71909,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -69781,8 +72176,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70020,8 +72420,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70245,8 +72650,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70473,8 +72883,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70699,8 +73114,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70923,8 +73343,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71147,8 +73572,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71369,8 +73799,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -71701,8 +74136,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71961,8 +74401,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -72064,8 +74509,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -72289,8 +74739,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -72392,8 +74847,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -73497,28 +75957,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -73542,28 +76017,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -73605,17 +76095,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -73624,19 +76124,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73662,17 +76172,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -73681,19 +76201,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73719,28 +76249,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -73764,28 +76309,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -73809,28 +76369,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -73854,28 +76429,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -73899,28 +76489,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -73944,28 +76549,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -73986,11 +76606,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -74086,17 +76711,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -74105,43 +76740,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -74167,17 +76827,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -74186,43 +76856,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -74248,28 +76943,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -76378,8 +79088,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -76477,8 +79192,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -76702,8 +79422,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -76805,8 +79530,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -77067,8 +79797,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77306,8 +80041,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77531,8 +80271,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77759,8 +80504,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77985,8 +80735,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78209,8 +80964,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78433,8 +81193,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78655,8 +81420,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -78987,8 +81757,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79247,8 +82022,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79350,8 +82130,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -79575,8 +82360,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79678,8 +82468,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -80783,28 +83578,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -80828,28 +83638,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -80891,17 +83716,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -80910,19 +83745,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -80948,17 +83793,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -80967,19 +83822,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -81005,28 +83870,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -81050,28 +83930,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -81095,28 +83990,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -81140,28 +84050,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -81185,28 +84110,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -81230,28 +84170,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -81272,11 +84227,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -81372,17 +84332,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -81391,43 +84361,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -81453,17 +84448,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -81472,43 +84477,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -81534,28 +84564,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -82985,17 +86030,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -83481,8 +86536,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#describes_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -83771,28 +86831,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -84388,8 +87463,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
               v = await this.#exclusiveOption_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -84613,8 +87693,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
               v = await this.#inclusiveOption_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -84867,8 +87952,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -85112,8 +88202,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -85465,28 +88560,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -85510,28 +88620,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -85604,28 +88729,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -85675,28 +88815,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -87058,8 +90213,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#subject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87279,8 +90439,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#object_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87379,8 +90544,13 @@ relationships?: (Object | URL)[];}
       
               v = await this.#object_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -87603,8 +90773,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#relationship_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87705,8 +90880,13 @@ relationships?: (Object | URL)[];}
       
               v = await this.#relationship_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -88066,28 +91246,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -88111,28 +91306,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -88156,28 +91366,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -89847,8 +93072,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -89946,8 +93176,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -90171,8 +93406,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90274,8 +93514,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -90536,8 +93781,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90775,8 +94025,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91000,8 +94255,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91228,8 +94488,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91454,8 +94719,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91678,8 +94948,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91902,8 +95177,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92124,8 +95404,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -92456,8 +95741,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92716,8 +96006,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92819,8 +96114,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -93044,8 +96344,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -93147,8 +96452,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -94252,28 +97562,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -94297,28 +97622,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -94360,17 +97700,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94379,19 +97729,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -94417,17 +97777,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94436,19 +97806,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -94474,28 +97854,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -94519,28 +97914,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -94564,28 +97974,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -94609,28 +98034,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -94654,28 +98094,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -94699,28 +98154,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -94741,11 +98211,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -94841,17 +98316,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94860,43 +98345,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -94922,17 +98432,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94941,43 +98461,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -95003,28 +98548,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -1,7 +1,7 @@
 export const snapshot = {};
 
 snapshot[`generateClasses() 1`] = `
-"// deno-lint-ignore-file ban-unused-ignore no-unused-vars prefer-const verbatim-module-syntax
+"// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-unused-vars prefer-const verbatim-module-syntax
 import jsonld from \\"@fedify/vocab-runtime/jsonld\\";
 import { getLogger } from \\"@logtape/logtape\\";
 import { type Span, SpanStatusCode, type TracerProvider, trace }
@@ -3663,6 +3663,18 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
+        {
+          const _ppM0 = await import(\\"./preprocessors.ts\\");
+          const _result = await _ppM0[\\"normalizeLinkToImage\\"](jsonLd as any, {
+            documentLoader,
+            contextLoader,
+            tracerProvider,
+            baseUrl,
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) return _result as Image;
+        }
+        
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -3977,6 +3989,18 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
+        {
+          const _ppM0 = await import(\\"./preprocessors.ts\\");
+          const _result = await _ppM0[\\"normalizeLinkToImage\\"](jsonLd as any, {
+            documentLoader,
+            contextLoader,
+            tracerProvider,
+            baseUrl,
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) return _result as Image;
+        }
+        
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -10739,6 +10763,29 @@ get urls(): ((URL | Link))[] {
     ) {
       if (v == null) continue;
     
+      {
+        let _handled: Image | undefined;
+      
+        if (_handled === undefined) {
+          const _ppM0 = await import(\\"./preprocessors.ts\\");
+          const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as Image;
+          }
+        }
+      
+        if (_handled !== undefined) {
+          _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(_handled);
+          continue;
+        }
+      }
+      
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
@@ -10772,6 +10819,29 @@ get urls(): ((URL | Link))[] {
     ) {
       if (v == null) continue;
     
+      {
+        let _handled: Image | undefined;
+      
+        if (_handled === undefined) {
+          const _ppM0 = await import(\\"./preprocessors.ts\\");
+          const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as Image;
+          }
+        }
+      
+        if (_handled !== undefined) {
+          _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(_handled);
+          continue;
+        }
+      }
+      
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10423,6 +10423,9 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -13271,6 +13274,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -14280,6 +14286,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -17370,6 +17379,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -18253,6 +18265,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -18762,6 +18777,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -19355,6 +19373,9 @@ unit?: string | null;numericalValue?: Decimal | null;}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -20359,6 +20380,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -20815,6 +20839,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -21413,6 +21440,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -22184,6 +22214,9 @@ get manualApprovals(): (URL)[] {
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -23245,6 +23278,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -23700,6 +23736,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -24617,6 +24656,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -25072,6 +25114,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -25988,6 +26033,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -26444,6 +26492,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -26896,6 +26947,9 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -27256,6 +27310,9 @@ endpoints?: (URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -28081,6 +28138,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -29064,6 +29124,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -29975,6 +30038,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -30836,6 +30902,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -31729,6 +31798,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -32230,6 +32302,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -32570,6 +32645,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -32904,6 +32982,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -38520,6 +38601,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -40079,6 +40163,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -40425,6 +40512,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -41431,6 +41521,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -42080,6 +42173,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -42509,6 +42605,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -42842,6 +42941,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -43182,6 +43284,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -47054,6 +47159,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -48999,6 +49107,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -49506,6 +49617,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -49840,6 +49954,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -50171,6 +50288,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -50973,6 +51093,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -51686,6 +51809,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -52020,6 +52146,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -52356,6 +52485,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -57972,6 +58104,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -60510,6 +60645,9 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -61209,6 +61347,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -61546,6 +61687,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -61880,6 +62024,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -62219,6 +62366,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -62552,6 +62702,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -62887,6 +63040,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -63221,6 +63377,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -63553,6 +63712,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -63850,6 +64012,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -64185,6 +64350,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -65193,6 +65361,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -66003,6 +66174,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -66802,6 +66976,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -72529,6 +72706,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -74089,6 +74269,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -79705,6 +79888,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -81722,6 +81908,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -82606,6 +82795,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -84290,6 +84482,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -84990,6 +85185,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -85323,6 +85521,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -86850,6 +87051,9 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -87366,6 +87570,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -92982,6 +93189,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -94759,6 +94969,9 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -95191,6 +95404,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -95524,6 +95740,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -96075,6 +96294,9 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -96510,6 +96732,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -96849,6 +97074,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -97185,6 +97413,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
@@ -97523,6 +97754,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
+    }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
@@ -97855,6 +98089,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
+    }
+    if (values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+      throw new TypeError(\\"Invalid @id: \\" + values[\\"@id\\"]);
     }
     if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -2342,7 +2342,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#attachment_fromJsonLd(obj, options);
+              v = await this.#attachment_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -2598,7 +2602,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#attribution_fromJsonLd(doc, options);
+            v = await this.#attribution_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -2696,7 +2704,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#attribution_fromJsonLd(obj, options);
+              v = await this.#attribution_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -2915,7 +2927,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#audience_fromJsonLd(doc, options);
+            v = await this.#audience_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -3012,7 +3028,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#audience_fromJsonLd(obj, options);
+              v = await this.#audience_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -3275,7 +3295,11 @@ get contents(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#context_fromJsonLd(obj, options);
+              v = await this.#context_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -3545,7 +3569,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#generator_fromJsonLd(obj, options);
+              v = await this.#generator_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -4467,7 +4495,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#replyTarget_fromJsonLd(doc, options);
+            v = await this.#replyTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -4564,7 +4596,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#replyTarget_fromJsonLd(obj, options);
+              v = await this.#replyTarget_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -4792,7 +4828,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#location_fromJsonLd(doc, options);
+            v = await this.#location_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -4889,7 +4929,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#location_fromJsonLd(obj, options);
+              v = await this.#location_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -5116,7 +5160,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#preview_fromJsonLd(doc, options);
+            v = await this.#preview_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5212,7 +5260,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -5444,7 +5496,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#replies_fromJsonLd(doc, options);
+            v = await this.#replies_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5668,7 +5724,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#shares_fromJsonLd(doc, options);
+            v = await this.#shares_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5892,7 +5952,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likes_fromJsonLd(doc, options);
+            v = await this.#likes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6110,7 +6174,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#emojiReactions_fromJsonLd(doc, options);
+            v = await this.#emojiReactions_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6380,7 +6448,11 @@ get summaries(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#tag_fromJsonLd(obj, options);
+              v = await this.#tag_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -6633,7 +6705,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#to_fromJsonLd(doc, options);
+            v = await this.#to_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6730,7 +6806,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#to_fromJsonLd(obj, options);
+              v = await this.#to_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -6949,7 +7029,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#bto_fromJsonLd(doc, options);
+            v = await this.#bto_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7046,7 +7130,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#bto_fromJsonLd(obj, options);
+              v = await this.#bto_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7265,7 +7353,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#cc_fromJsonLd(doc, options);
+            v = await this.#cc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7362,7 +7454,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#cc_fromJsonLd(obj, options);
+              v = await this.#cc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7581,7 +7677,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#bcc_fromJsonLd(doc, options);
+            v = await this.#bcc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7678,7 +7778,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#bcc_fromJsonLd(obj, options);
+              v = await this.#bcc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7960,7 +8064,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#proof_fromJsonLd(doc, options);
+            v = await this.#proof_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8056,7 +8164,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#proof_fromJsonLd(obj, options);
+              v = await this.#proof_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -8314,7 +8426,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+            v = await this.#likeAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8532,7 +8648,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+            v = await this.#replyAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8750,7 +8870,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+            v = await this.#announceAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -10299,8 +10423,8 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -13147,8 +13271,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -13585,7 +13709,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -13826,7 +13954,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -14149,8 +14281,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -15214,7 +15346,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#actor_fromJsonLd(doc, options);
+            v = await this.#actor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15312,7 +15448,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#actor_fromJsonLd(obj, options);
+              v = await this.#actor_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -15532,7 +15672,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15630,7 +15774,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -15853,7 +16001,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#target_fromJsonLd(doc, options);
+            v = await this.#target_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15954,7 +16106,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#target_fromJsonLd(obj, options);
+              v = await this.#target_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16174,7 +16330,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#result_fromJsonLd(doc, options);
+            v = await this.#result_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16272,7 +16432,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#result_fromJsonLd(obj, options);
+              v = await this.#result_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16493,7 +16657,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#origin_fromJsonLd(doc, options);
+            v = await this.#origin_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16592,7 +16760,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#origin_fromJsonLd(obj, options);
+              v = await this.#origin_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16811,7 +16983,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#instrument_fromJsonLd(doc, options);
+            v = await this.#instrument_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16908,7 +17084,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#instrument_fromJsonLd(obj, options);
+              v = await this.#instrument_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -17190,8 +17370,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -18073,8 +18253,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -18583,8 +18763,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -19176,8 +19356,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -19676,7 +19856,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -19893,7 +20077,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -20171,8 +20359,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -20628,8 +20816,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -21226,8 +21414,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -21997,8 +22185,8 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -22554,7 +22742,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -22771,7 +22963,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -23049,8 +23245,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -23505,8 +23701,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -23918,7 +24114,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -24135,7 +24335,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -24413,8 +24617,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -24869,8 +25073,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -25281,7 +25485,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -25498,7 +25706,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -25776,8 +25988,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -26232,8 +26444,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -26684,8 +26896,8 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -27045,8 +27257,8 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -27870,8 +28082,8 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -28572,7 +28784,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#owner_fromJsonLd(doc, options);
+            v = await this.#owner_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -28848,8 +29064,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -29472,7 +29688,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#controller_fromJsonLd(doc, options);
+            v = await this.#controller_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -29755,8 +29975,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -30617,8 +30837,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -31509,8 +31729,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -32010,8 +32230,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -32350,8 +32570,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -32685,8 +32905,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -33962,7 +34182,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34057,7 +34281,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -34278,7 +34506,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34377,7 +34609,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -34635,7 +34871,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34870,7 +35110,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35091,7 +35335,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35315,7 +35563,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35537,7 +35789,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35757,7 +36013,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35977,7 +36237,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36195,7 +36459,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -36523,7 +36791,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36779,7 +37051,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36878,7 +37154,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -37099,7 +37379,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -37198,7 +37482,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -38232,8 +38520,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -39791,8 +40079,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -40138,8 +40426,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -40571,7 +40859,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -40812,7 +41104,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -41135,8 +41431,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -41784,8 +42080,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -42213,8 +42509,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -42547,8 +42843,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -42887,8 +43183,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -43643,7 +43939,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#current_fromJsonLd(doc, options);
+            v = await this.#current_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -43861,7 +44161,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#first_fromJsonLd(doc, options);
+            v = await this.#first_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44079,7 +44383,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#last_fromJsonLd(doc, options);
+            v = await this.#last_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44307,7 +44615,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -44525,7 +44837,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likesOf_fromJsonLd(doc, options);
+            v = await this.#likesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44742,7 +45058,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#sharesOf_fromJsonLd(doc, options);
+            v = await this.#sharesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44959,7 +45279,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#repliesOf_fromJsonLd(doc, options);
+            v = await this.#repliesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45176,7 +45500,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inboxOf_fromJsonLd(doc, options);
+            v = await this.#inboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45393,7 +45721,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outboxOf_fromJsonLd(doc, options);
+            v = await this.#outboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45610,7 +45942,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followersOf_fromJsonLd(doc, options);
+            v = await this.#followersOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45827,7 +46163,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followingOf_fromJsonLd(doc, options);
+            v = await this.#followingOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -46044,7 +46384,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#likedOf_fromJsonLd(doc, options);
+            v = await this.#likedOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -46710,8 +47054,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -47897,7 +48241,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#partOf_fromJsonLd(doc, options);
+            v = await this.#partOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48113,7 +48461,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#next_fromJsonLd(doc, options);
+            v = await this.#next_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48330,7 +48682,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#prev_fromJsonLd(doc, options);
+            v = await this.#prev_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48643,8 +48999,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -49150,8 +49506,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -49484,8 +49840,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -49816,8 +50172,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -50617,8 +50973,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -51330,8 +51686,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -51665,8 +52021,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -52001,8 +52357,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -53278,7 +53634,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -53373,7 +53733,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -53594,7 +53958,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -53693,7 +54061,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -53951,7 +54323,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54186,7 +54562,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54407,7 +54787,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54631,7 +55015,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54853,7 +55241,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55073,7 +55465,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55293,7 +55689,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55511,7 +55911,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -55839,7 +56243,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56095,7 +56503,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56194,7 +56606,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -56415,7 +56831,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56514,7 +56934,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -57548,8 +57972,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -59627,7 +60051,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -60082,8 +60510,8 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -60781,8 +61209,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -61118,8 +61546,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -61453,8 +61881,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -61791,8 +62219,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -62125,8 +62553,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -62459,8 +62887,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -62793,8 +63221,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -63125,8 +63553,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -63423,8 +63851,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -63758,8 +64186,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -64193,7 +64621,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -64434,7 +64866,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -64757,8 +65193,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -65318,7 +65754,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -65563,8 +66003,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -66065,7 +66505,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -66359,8 +66803,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -67747,7 +68191,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -67842,7 +68290,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -68063,7 +68515,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68162,7 +68618,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -68420,7 +68880,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68655,7 +69119,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68876,7 +69344,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69100,7 +69572,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69322,7 +69798,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69542,7 +70022,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69762,7 +70246,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69980,7 +70468,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -70308,7 +70800,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70564,7 +71060,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70663,7 +71163,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -70884,7 +71388,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70983,7 +71491,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -72017,8 +72529,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -73578,8 +74090,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -74855,7 +75367,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -74950,7 +75466,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -75171,7 +75691,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75270,7 +75794,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -75528,7 +76056,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75763,7 +76295,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75984,7 +76520,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76208,7 +76748,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76430,7 +76974,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76650,7 +77198,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76870,7 +77422,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77088,7 +77644,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -77416,7 +77976,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77672,7 +78236,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77771,7 +78339,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -77992,7 +78564,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -78091,7 +78667,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -79125,8 +79705,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -81142,8 +81722,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -81780,7 +82360,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#describes_fromJsonLd(doc, options);
+            v = await this.#describes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -82023,8 +82607,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -82672,7 +83256,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+              v = await this.#exclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -82893,7 +83481,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+              v = await this.#inclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -83143,7 +83735,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -83384,7 +83980,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -83690,8 +84290,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -84390,8 +84990,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -84724,8 +85324,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -85285,7 +85885,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#subject_fromJsonLd(doc, options);
+            v = await this.#subject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85502,7 +86106,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85598,7 +86206,11 @@ relationships?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -85818,7 +86430,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#relationship_fromJsonLd(doc, options);
+            v = await this.#relationship_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85916,7 +86532,11 @@ relationships?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#relationship_fromJsonLd(obj, options);
+              v = await this.#relationship_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -86230,8 +86850,8 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -86747,8 +87367,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -88024,7 +88644,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88119,7 +88743,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -88340,7 +88968,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88439,7 +89071,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -88697,7 +89333,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88932,7 +89572,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89153,7 +89797,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89377,7 +90025,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89599,7 +90251,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89819,7 +90475,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90039,7 +90699,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90257,7 +90921,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -90585,7 +91253,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90841,7 +91513,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90940,7 +91616,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -91161,7 +91841,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -91260,7 +91944,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -92294,8 +92982,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -94071,8 +94759,8 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -94503,8 +95191,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -94837,8 +95525,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -95387,8 +96075,8 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -95822,8 +96510,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -96161,8 +96849,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -96498,8 +97186,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -96835,8 +97523,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {
@@ -97168,8 +97856,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
   if (\\"@type\\" in values) {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10593,16 +10593,28 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10639,23 +10651,43 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10690,7 +10722,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10750,12 +10786,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10839,12 +10883,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10875,7 +10927,11 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10901,7 +10957,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10930,7 +10990,11 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10956,7 +11020,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10992,12 +11060,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11035,12 +11111,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11078,12 +11162,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11140,7 +11232,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11173,7 +11269,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11206,7 +11306,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11239,7 +11343,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11321,12 +11429,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11385,13 +11501,25 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11426,7 +11554,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11459,7 +11591,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11492,7 +11628,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11525,7 +11665,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11600,7 +11744,11 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11633,7 +11781,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11654,7 +11806,11 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11686,9 +11842,17 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11720,7 +11884,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11753,7 +11921,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11786,7 +11958,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -14017,7 +14193,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14076,7 +14256,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17188,23 +17372,43 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17239,7 +17443,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17272,7 +17480,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17305,7 +17517,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17338,7 +17554,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17371,7 +17591,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19977,7 +20201,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20010,7 +20238,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -21000,7 +21232,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21021,7 +21257,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21042,7 +21282,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21063,7 +21307,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21759,9 +22007,17 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21792,9 +22048,17 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22801,7 +23065,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22834,7 +23102,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24157,7 +24429,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24190,7 +24466,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25512,7 +25792,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25545,7 +25829,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26403,9 +26691,17 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27589,7 +27885,11 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28540,23 +28840,43 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29420,23 +29740,43 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30270,9 +30610,17 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30292,7 +30640,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30313,7 +30665,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30334,7 +30690,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31136,7 +31496,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31157,7 +31521,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37869,7 +38237,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37902,7 +38274,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37955,11 +38331,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37996,11 +38380,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38035,7 +38427,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38068,7 +38464,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38101,7 +38501,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38134,7 +38538,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38167,7 +38575,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38200,7 +38612,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38221,7 +38637,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38328,23 +38748,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38381,23 +38821,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38432,7 +38892,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40652,7 +41116,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40711,7 +41179,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46249,7 +46721,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46282,7 +46758,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46315,7 +46795,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46351,12 +46835,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46391,7 +46883,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46424,7 +46920,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46457,7 +46957,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46490,7 +46994,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46523,7 +47031,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46556,7 +47068,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46589,7 +47105,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46622,7 +47142,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48104,7 +48628,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48137,7 +48665,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48170,7 +48702,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -50049,9 +50585,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50082,9 +50626,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50115,9 +50667,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50148,9 +50708,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50181,9 +50749,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50214,9 +50790,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56962,7 +57546,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56995,7 +57583,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57048,11 +57640,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57089,11 +57689,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57128,7 +57736,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57161,7 +57773,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57194,7 +57810,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57227,7 +57847,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57260,7 +57884,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57293,7 +57921,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57314,7 +57946,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57421,23 +58057,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57474,23 +58130,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57525,7 +58201,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59371,9 +60051,17 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59522,12 +60210,20 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -64028,7 +64724,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64087,7 +64787,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64829,12 +65533,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65617,12 +66329,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71288,7 +72008,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71321,7 +72045,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71374,11 +72102,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71415,11 +72151,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71454,7 +72198,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71487,7 +72235,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71520,7 +72272,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71553,7 +72309,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71586,7 +72346,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71619,7 +72383,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71640,7 +72408,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71747,23 +72519,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71800,23 +72592,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71851,7 +72663,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -78300,7 +79116,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78333,7 +79153,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78386,11 +79210,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78427,11 +79259,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78466,7 +79306,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78499,7 +79343,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78532,7 +79380,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78565,7 +79417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78598,7 +79454,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78631,7 +79491,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78652,7 +79516,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78759,23 +79627,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78812,23 +79700,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78863,7 +79771,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80290,9 +81202,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81070,7 +81990,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82733,7 +83657,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82766,7 +83694,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82848,7 +83780,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82907,7 +83843,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -85257,7 +86197,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85290,7 +86234,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85323,7 +86271,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -91333,7 +92285,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91366,7 +92322,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91419,11 +92379,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91460,11 +92428,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91499,7 +92475,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91532,7 +92512,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91565,7 +92549,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91598,7 +92586,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91631,7 +92623,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91664,7 +92660,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91685,7 +92685,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91792,23 +92796,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91845,23 +92869,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91896,7 +92940,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -2334,7 +2334,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attachment\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attachment_fromJsonLd(obj, options);
+              v = await this.#attachment_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -2588,7 +2592,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"attributedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#attribution_fromJsonLd(doc, options);
+            v = await this.#attribution_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -2684,7 +2692,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attributedTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attribution_fromJsonLd(obj, options);
+              v = await this.#attribution_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -2901,7 +2913,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"audience\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#audience_fromJsonLd(doc, options);
+            v = await this.#audience_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -2996,7 +3012,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"audience\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#audience_fromJsonLd(obj, options);
+              v = await this.#audience_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3257,7 +3277,11 @@ get contents(): ((string | LanguageString))[] {
               \\"context\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#context_fromJsonLd(obj, options);
+              v = await this.#context_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3525,7 +3549,11 @@ get names(): ((string | LanguageString))[] {
               \\"generator\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#generator_fromJsonLd(obj, options);
+              v = await this.#generator_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3762,7 +3790,11 @@ get names(): ((string | LanguageString))[] {
             \\"icon\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#icon_fromJsonLd(doc, options);
+            v = await this.#icon_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -3858,7 +3890,11 @@ get names(): ((string | LanguageString))[] {
               \\"icon\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#icon_fromJsonLd(obj, options);
+              v = await this.#icon_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4095,7 +4131,11 @@ get names(): ((string | LanguageString))[] {
             \\"image\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#image_fromJsonLd(doc, options);
+            v = await this.#image_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4191,7 +4231,11 @@ get names(): ((string | LanguageString))[] {
               \\"image\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#image_fromJsonLd(obj, options);
+              v = await this.#image_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4417,7 +4461,11 @@ get names(): ((string | LanguageString))[] {
             \\"inReplyTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyTarget_fromJsonLd(doc, options);
+            v = await this.#replyTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4512,7 +4560,11 @@ get names(): ((string | LanguageString))[] {
               \\"inReplyTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#replyTarget_fromJsonLd(obj, options);
+              v = await this.#replyTarget_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4738,7 +4790,11 @@ get names(): ((string | LanguageString))[] {
             \\"location\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#location_fromJsonLd(doc, options);
+            v = await this.#location_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4833,7 +4889,11 @@ get names(): ((string | LanguageString))[] {
               \\"location\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#location_fromJsonLd(obj, options);
+              v = await this.#location_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -5058,7 +5118,11 @@ get names(): ((string | LanguageString))[] {
             \\"preview\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#preview_fromJsonLd(doc, options);
+            v = await this.#preview_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5152,7 +5216,11 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -5382,7 +5450,11 @@ get names(): ((string | LanguageString))[] {
             \\"replies\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replies_fromJsonLd(doc, options);
+            v = await this.#replies_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5604,7 +5676,11 @@ get names(): ((string | LanguageString))[] {
             \\"shares\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#shares_fromJsonLd(doc, options);
+            v = await this.#shares_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5826,7 +5902,11 @@ get names(): ((string | LanguageString))[] {
             \\"likes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likes_fromJsonLd(doc, options);
+            v = await this.#likes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6042,7 +6122,11 @@ get names(): ((string | LanguageString))[] {
             \\"emojiReactions\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#emojiReactions_fromJsonLd(doc, options);
+            v = await this.#emojiReactions_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6310,7 +6394,11 @@ get summaries(): ((string | LanguageString))[] {
               \\"tag\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#tag_fromJsonLd(obj, options);
+              v = await this.#tag_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -6561,7 +6649,11 @@ get urls(): ((URL | Link))[] {
             \\"to\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#to_fromJsonLd(doc, options);
+            v = await this.#to_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6656,7 +6748,11 @@ get urls(): ((URL | Link))[] {
               \\"to\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#to_fromJsonLd(obj, options);
+              v = await this.#to_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -6873,7 +6969,11 @@ get urls(): ((URL | Link))[] {
             \\"bto\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bto_fromJsonLd(doc, options);
+            v = await this.#bto_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6968,7 +7068,11 @@ get urls(): ((URL | Link))[] {
               \\"bto\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bto_fromJsonLd(obj, options);
+              v = await this.#bto_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7185,7 +7289,11 @@ get urls(): ((URL | Link))[] {
             \\"cc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#cc_fromJsonLd(doc, options);
+            v = await this.#cc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7280,7 +7388,11 @@ get urls(): ((URL | Link))[] {
               \\"cc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#cc_fromJsonLd(obj, options);
+              v = await this.#cc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7497,7 +7609,11 @@ get urls(): ((URL | Link))[] {
             \\"bcc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bcc_fromJsonLd(doc, options);
+            v = await this.#bcc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7592,7 +7708,11 @@ get urls(): ((URL | Link))[] {
               \\"bcc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bcc_fromJsonLd(obj, options);
+              v = await this.#bcc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7872,7 +7992,11 @@ get urls(): ((URL | Link))[] {
             \\"proof\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#proof_fromJsonLd(doc, options);
+            v = await this.#proof_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7966,7 +8090,11 @@ get urls(): ((URL | Link))[] {
               \\"proof\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#proof_fromJsonLd(obj, options);
+              v = await this.#proof_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -8222,7 +8350,11 @@ get urls(): ((URL | Link))[] {
             \\"likeAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+            v = await this.#likeAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -8438,7 +8570,11 @@ get urls(): ((URL | Link))[] {
             \\"replyAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+            v = await this.#replyAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -8654,7 +8790,11 @@ get urls(): ((URL | Link))[] {
             \\"announceAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+            v = await this.#announceAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -10202,7 +10342,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -10503,16 +10643,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10549,23 +10689,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10600,7 +10740,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10660,12 +10800,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10749,12 +10889,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10785,7 +10925,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10811,7 +10951,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10840,7 +10980,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10866,7 +11006,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10902,12 +11042,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10945,12 +11085,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10988,12 +11128,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11050,7 +11190,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11083,7 +11223,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11116,7 +11256,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11149,7 +11289,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11231,12 +11371,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11295,13 +11435,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11336,7 +11476,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11369,7 +11509,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11402,7 +11542,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11435,7 +11575,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11510,7 +11650,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11543,7 +11683,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11564,7 +11704,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11596,9 +11736,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11630,7 +11770,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11663,7 +11803,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11696,7 +11836,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -12874,7 +13014,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -13311,7 +13451,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -13550,7 +13694,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -13872,7 +14020,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -13923,7 +14071,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -13982,7 +14130,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -14928,7 +15076,11 @@ instruments?: (Object | URL)[];}
             \\"actor\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#actor_fromJsonLd(doc, options);
+            v = await this.#actor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15024,7 +15176,11 @@ instruments?: (Object | URL)[];}
               \\"actor\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#actor_fromJsonLd(obj, options);
+              v = await this.#actor_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15242,7 +15398,11 @@ instruments?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15338,7 +15498,11 @@ instruments?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15559,7 +15723,11 @@ instruments?: (Object | URL)[];}
             \\"target\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#target_fromJsonLd(doc, options);
+            v = await this.#target_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15658,7 +15826,11 @@ instruments?: (Object | URL)[];}
               \\"target\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#target_fromJsonLd(obj, options);
+              v = await this.#target_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15876,7 +16048,11 @@ instruments?: (Object | URL)[];}
             \\"result\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#result_fromJsonLd(doc, options);
+            v = await this.#result_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15972,7 +16148,11 @@ instruments?: (Object | URL)[];}
               \\"result\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#result_fromJsonLd(obj, options);
+              v = await this.#result_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16191,7 +16371,11 @@ instruments?: (Object | URL)[];}
             \\"origin\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#origin_fromJsonLd(doc, options);
+            v = await this.#origin_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -16288,7 +16472,11 @@ instruments?: (Object | URL)[];}
               \\"origin\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#origin_fromJsonLd(obj, options);
+              v = await this.#origin_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16505,7 +16693,11 @@ instruments?: (Object | URL)[];}
             \\"instrument\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#instrument_fromJsonLd(doc, options);
+            v = await this.#instrument_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -16600,7 +16792,11 @@ instruments?: (Object | URL)[];}
               \\"instrument\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#instrument_fromJsonLd(obj, options);
+              v = await this.#instrument_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16881,7 +17077,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -17070,23 +17266,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17121,7 +17317,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17154,7 +17350,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17187,7 +17383,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17220,7 +17416,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17253,7 +17449,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17724,7 +17920,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18227,7 +18423,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18813,7 +19009,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19312,7 +19508,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -19527,7 +19727,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -19804,7 +20008,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19855,7 +20059,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -19888,7 +20092,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20253,7 +20457,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20844,7 +21048,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20878,7 +21082,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -20899,7 +21103,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -20920,7 +21124,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -20941,7 +21145,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21592,7 +21796,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21637,9 +21841,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21670,9 +21874,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22132,7 +22336,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -22347,7 +22555,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -22624,7 +22836,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -22675,7 +22887,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22708,7 +22920,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23072,7 +23284,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -23484,7 +23696,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -23699,7 +23915,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -23976,7 +24196,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24027,7 +24247,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24060,7 +24280,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24424,7 +24644,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24835,7 +25055,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -25050,7 +25274,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -25327,7 +25555,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25378,7 +25606,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25411,7 +25639,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25775,7 +26003,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26220,7 +26448,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26269,9 +26497,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26573,7 +26801,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27391,7 +27619,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27455,7 +27683,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28081,7 +28309,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
             \\"owner\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#owner_fromJsonLd(doc, options);
+            v = await this.#owner_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -28356,7 +28588,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -28404,23 +28636,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -28952,7 +29184,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
             \\"controller\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#controller_fromJsonLd(doc, options);
+            v = await this.#controller_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -29234,7 +29470,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -29282,23 +29518,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30069,7 +30305,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30132,9 +30368,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30154,7 +30390,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30175,7 +30411,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30196,7 +30432,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -30941,7 +31177,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30998,7 +31234,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31019,7 +31255,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31434,7 +31670,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31774,7 +32010,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32109,7 +32345,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -33385,7 +33621,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -33478,7 +33718,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -33697,7 +33941,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -33794,7 +34042,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -34050,7 +34302,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34283,7 +34539,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34502,7 +34762,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34724,7 +34988,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34944,7 +35212,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35162,7 +35434,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35380,7 +35656,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35596,7 +35876,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -35922,7 +36206,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36176,7 +36464,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36273,7 +36565,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -36492,7 +36788,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36589,7 +36889,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -37622,7 +37926,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37697,7 +38001,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37730,7 +38034,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37783,11 +38087,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37824,11 +38128,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37863,7 +38167,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -37896,7 +38200,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -37929,7 +38233,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -37962,7 +38266,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -37995,7 +38299,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38028,7 +38332,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38049,7 +38353,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38156,23 +38460,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38209,23 +38513,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38260,7 +38564,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39085,7 +39389,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39432,7 +39736,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39864,7 +40168,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -40103,7 +40411,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -40425,7 +40737,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40476,7 +40788,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40535,7 +40847,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41066,7 +41378,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41495,7 +41807,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41829,7 +42141,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42169,7 +42481,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42924,7 +43236,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"current\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#current_fromJsonLd(doc, options);
+            v = await this.#current_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43140,7 +43456,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"first\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#first_fromJsonLd(doc, options);
+            v = await this.#first_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43356,7 +43676,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"last\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#last_fromJsonLd(doc, options);
+            v = await this.#last_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43582,7 +43906,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"items\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -43798,7 +44126,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likesOf_fromJsonLd(doc, options);
+            v = await this.#likesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44013,7 +44345,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"sharesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#sharesOf_fromJsonLd(doc, options);
+            v = await this.#sharesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44228,7 +44564,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"repliesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#repliesOf_fromJsonLd(doc, options);
+            v = await this.#repliesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44443,7 +44783,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"inboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inboxOf_fromJsonLd(doc, options);
+            v = await this.#inboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44658,7 +45002,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"outboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outboxOf_fromJsonLd(doc, options);
+            v = await this.#outboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44873,7 +45221,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followersOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followersOf_fromJsonLd(doc, options);
+            v = await this.#followersOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45088,7 +45440,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followingOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followingOf_fromJsonLd(doc, options);
+            v = await this.#followingOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45303,7 +45659,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likedOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likedOf_fromJsonLd(doc, options);
+            v = await this.#likedOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45968,7 +46328,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46049,7 +46409,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46082,7 +46442,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46115,7 +46475,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46151,12 +46511,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46191,7 +46551,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46224,7 +46584,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46257,7 +46617,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46290,7 +46650,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46323,7 +46683,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46356,7 +46716,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46389,7 +46749,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46422,7 +46782,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47102,7 +47462,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"partOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#partOf_fromJsonLd(doc, options);
+            v = await this.#partOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47316,7 +47680,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"next\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#next_fromJsonLd(doc, options);
+            v = await this.#next_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47531,7 +47899,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"prev\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#prev_fromJsonLd(doc, options);
+            v = await this.#prev_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47843,7 +48215,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -47898,7 +48270,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -47931,7 +48303,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -47964,7 +48336,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48338,7 +48710,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48672,7 +49044,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49004,7 +49376,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49798,7 +50170,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49843,9 +50215,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -49876,9 +50248,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -49909,9 +50281,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -49942,9 +50314,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -49975,9 +50347,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50008,9 +50380,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50463,7 +50835,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50798,7 +51170,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51134,7 +51506,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -52410,7 +52782,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -52503,7 +52879,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -52722,7 +53102,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -52819,7 +53203,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -53075,7 +53463,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53308,7 +53700,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53527,7 +53923,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53749,7 +54149,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53969,7 +54373,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54187,7 +54595,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54405,7 +54817,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54621,7 +55037,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -54947,7 +55367,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55201,7 +55625,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55298,7 +55726,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -55517,7 +55949,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55614,7 +56050,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -56647,7 +57087,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56722,7 +57162,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56755,7 +57195,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -56808,11 +57248,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -56849,11 +57289,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -56888,7 +57328,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -56921,7 +57361,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -56954,7 +57394,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -56987,7 +57427,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57020,7 +57460,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57053,7 +57493,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57074,7 +57514,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57181,23 +57621,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57234,23 +57674,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57285,7 +57725,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -58622,7 +59062,11 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -59076,7 +59520,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59129,9 +59573,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59280,12 +59724,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -59759,7 +60203,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60096,7 +60540,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60431,7 +60875,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60769,7 +61213,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61103,7 +61547,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61437,7 +61881,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61771,7 +62215,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62103,7 +62547,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62401,7 +62845,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62736,7 +63180,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63170,7 +63614,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -63409,7 +63857,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -63731,7 +64183,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63782,7 +64234,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -63841,7 +64293,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64283,7 +64735,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -64527,7 +64983,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64581,12 +65037,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65020,7 +65476,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -65313,7 +65773,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65367,12 +65827,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -66692,7 +67152,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -66785,7 +67249,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -67004,7 +67472,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67101,7 +67573,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -67357,7 +67833,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67590,7 +68070,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67809,7 +68293,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68031,7 +68519,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68251,7 +68743,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68469,7 +68965,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68687,7 +69187,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68903,7 +69407,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -69229,7 +69737,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69483,7 +69995,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69580,7 +70096,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -69799,7 +70319,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69896,7 +70420,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -70929,7 +71457,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -71004,7 +71532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71037,7 +71565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71090,11 +71618,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71131,11 +71659,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71170,7 +71698,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71203,7 +71731,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71236,7 +71764,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71269,7 +71797,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71302,7 +71830,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71335,7 +71863,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71356,7 +71884,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71463,23 +71991,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71516,23 +72044,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71567,7 +72095,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72394,7 +72922,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -73670,7 +74198,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -73763,7 +74295,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -73982,7 +74518,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74079,7 +74619,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -74335,7 +74879,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74568,7 +75116,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74787,7 +75339,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75009,7 +75565,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75229,7 +75789,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75447,7 +76011,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75665,7 +76233,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75881,7 +76453,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -76207,7 +76783,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76461,7 +77041,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76558,7 +77142,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -76777,7 +77365,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76874,7 +77466,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -77907,7 +78503,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -77982,7 +78578,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78015,7 +78611,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78068,11 +78664,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78109,11 +78705,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78148,7 +78744,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78181,7 +78777,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78214,7 +78810,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78247,7 +78843,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78280,7 +78876,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78313,7 +78909,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78334,7 +78930,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78441,23 +79037,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78494,23 +79090,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78545,7 +79141,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -79828,7 +80424,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -79972,9 +80568,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -80457,7 +81053,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"describes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#describes_fromJsonLd(doc, options);
+            v = await this.#describes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -80699,7 +81299,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -80750,7 +81350,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -81343,7 +81943,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"oneOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+              v = await this.#exclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -81562,7 +82166,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"anyOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+              v = await this.#inclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -81810,7 +82418,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -82049,7 +82661,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -82354,7 +82970,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -82405,7 +83021,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82438,7 +83054,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82520,7 +83136,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82579,7 +83195,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83038,7 +83654,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83372,7 +83988,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83932,7 +84548,11 @@ relationships?: (Object | URL)[];}
             \\"subject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#subject_fromJsonLd(doc, options);
+            v = await this.#subject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84147,7 +84767,11 @@ relationships?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84241,7 +84865,11 @@ relationships?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -84459,7 +85087,11 @@ relationships?: (Object | URL)[];}
             \\"relationship\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#relationship_fromJsonLd(doc, options);
+            v = await this.#relationship_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84555,7 +85187,11 @@ relationships?: (Object | URL)[];}
               \\"relationship\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#relationship_fromJsonLd(obj, options);
+              v = await this.#relationship_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -84868,7 +85504,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -84919,7 +85555,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -84952,7 +85588,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -84985,7 +85621,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -85373,7 +86009,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -86649,7 +87285,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -86742,7 +87382,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -86961,7 +87605,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87058,7 +87706,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -87314,7 +87966,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87547,7 +88203,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87766,7 +88426,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87988,7 +88652,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88208,7 +88876,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88426,7 +89098,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88644,7 +89320,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88860,7 +89540,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -89186,7 +89870,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89440,7 +90128,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89537,7 +90229,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -89756,7 +90452,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89853,7 +90553,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -90886,7 +91590,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -90961,7 +91665,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -90994,7 +91698,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91047,11 +91751,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91088,11 +91792,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91127,7 +91831,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91160,7 +91864,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91193,7 +91897,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91226,7 +91930,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91259,7 +91963,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91292,7 +91996,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91313,7 +92017,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91420,23 +92124,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91473,23 +92177,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91524,7 +92228,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -92560,7 +93264,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -92992,7 +93696,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93326,7 +94030,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93876,7 +94580,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94311,7 +95015,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94650,7 +95354,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94987,7 +95691,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95324,7 +96028,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95657,7 +96361,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -46,6 +46,7 @@ export class Object {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -74,6 +75,10 @@ export class Object {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -203,6 +208,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -3782,7 +3789,7 @@ get names(): ((string | LanguageString))[] {
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       
           }
@@ -3884,7 +3891,7 @@ get names(): ((string | LanguageString))[] {
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       
             }
@@ -4129,7 +4136,7 @@ get names(): ((string | LanguageString))[] {
             v = await this.#image_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       
           }
@@ -4231,7 +4238,7 @@ get names(): ((string | LanguageString))[] {
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       
             }
@@ -18146,6 +18153,7 @@ export class PropertyValue {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18174,6 +18182,10 @@ export class PropertyValue {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -18206,6 +18218,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -18747,6 +18761,7 @@ export class Measure {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18775,6 +18790,10 @@ export class Measure {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -18807,6 +18826,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -20694,6 +20715,7 @@ export class InteractionPolicy {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -20722,6 +20744,10 @@ export class InteractionPolicy {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -20756,6 +20782,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -21486,6 +21514,7 @@ export class InteractionRule {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -21514,6 +21543,10 @@ export class InteractionRule {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -21548,6 +21581,8 @@ manualApprovals?: (URL)[];}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -26281,6 +26316,7 @@ export class DidService {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -26309,6 +26345,10 @@ export class DidService {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -26341,6 +26381,8 @@ endpoints?: (URL)[];}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -27085,6 +27127,7 @@ export class DataIntegrityProof {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -27113,6 +27156,10 @@ export class DataIntegrityProof {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -27150,6 +27197,8 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -28124,6 +28173,7 @@ export class CryptographicKey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -28152,6 +28202,10 @@ export class CryptographicKey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -28186,6 +28240,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -29017,6 +29073,7 @@ export class Multikey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -29045,6 +29102,10 @@ export class Multikey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -29079,6 +29140,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -29915,6 +29978,7 @@ export class Intent {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -29943,6 +30007,10 @@ export class Intent {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -29978,6 +30046,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -49826,6 +49896,7 @@ export class Endpoints {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -49854,6 +49925,10 @@ export class Endpoints {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -49890,6 +49965,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -58783,6 +58860,7 @@ export class Link {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -58811,6 +58889,10 @@ export class Link {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -58853,6 +58935,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -93514,6 +93598,7 @@ export class Source {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -93542,6 +93627,10 @@ export class Source {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -93575,6 +93664,8 @@ contents?: ((string | LanguageString))[];mediaType?: string | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if (\\"$warning\\" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10423,7 +10423,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -13271,7 +13271,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -14281,7 +14281,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -17370,7 +17370,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -18253,7 +18253,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -18763,7 +18763,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -19356,7 +19356,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -20359,7 +20359,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -20816,7 +20816,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -21414,7 +21414,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -22185,7 +22185,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -23245,7 +23245,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -23701,7 +23701,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -24617,7 +24617,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -25073,7 +25073,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -25988,7 +25988,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -26444,7 +26444,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -26896,7 +26896,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -27257,7 +27257,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -28082,7 +28082,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -29064,7 +29064,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -29975,7 +29975,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -30837,7 +30837,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -31729,7 +31729,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -32230,7 +32230,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -32570,7 +32570,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -32905,7 +32905,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -38520,7 +38520,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -40079,7 +40079,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -40426,7 +40426,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -41431,7 +41431,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -42080,7 +42080,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -42509,7 +42509,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -42843,7 +42843,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -43183,7 +43183,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -47054,7 +47054,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -48999,7 +48999,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -49506,7 +49506,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -49840,7 +49840,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -50172,7 +50172,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -50973,7 +50973,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -51686,7 +51686,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -52021,7 +52021,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -52357,7 +52357,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -57972,7 +57972,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -60510,7 +60510,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -61209,7 +61209,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -61546,7 +61546,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -61881,7 +61881,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -62219,7 +62219,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -62553,7 +62553,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -62887,7 +62887,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -63221,7 +63221,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -63553,7 +63553,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -63851,7 +63851,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -64186,7 +64186,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -65193,7 +65193,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -66003,7 +66003,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -66803,7 +66803,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -72529,7 +72529,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -74090,7 +74090,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -79705,7 +79705,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -81722,7 +81722,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -82607,7 +82607,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -84290,7 +84290,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -84990,7 +84990,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -85324,7 +85324,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -86850,7 +86850,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -87367,7 +87367,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -92982,7 +92982,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -94759,7 +94759,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -95191,7 +95191,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -95525,7 +95525,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -96075,7 +96075,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -96510,7 +96510,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -96849,7 +96849,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -97186,7 +97186,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -97523,7 +97523,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   
@@ -97856,7 +97856,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\")) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10423,8 +10423,8 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -10691,7 +10691,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     
@@ -10726,26 +10726,26 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10784,41 +10784,41 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10855,9 +10855,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10919,18 +10919,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11016,18 +11016,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11060,9 +11060,9 @@ get urls(): ((URL | Link))[] {
             tracerProvider: options.tracerProvider,
             baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
+        : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11090,9 +11090,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11123,9 +11123,9 @@ get urls(): ((URL | Link))[] {
             tracerProvider: options.tracerProvider,
             baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)),
+        : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11153,9 +11153,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11193,18 +11193,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11244,18 +11244,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11295,18 +11295,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11365,9 +11365,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11402,9 +11402,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11439,9 +11439,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11476,9 +11476,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11562,18 +11562,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11634,23 +11634,23 @@ get urls(): ((URL | Link))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+        : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11687,9 +11687,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11724,9 +11724,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11761,9 +11761,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11798,9 +11798,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11877,9 +11877,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11914,9 +11914,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11939,9 +11939,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11975,15 +11975,15 @@ get urls(): ((URL | Link))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12017,9 +12017,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12054,9 +12054,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12091,9 +12091,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13271,8 +13271,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -14281,8 +14281,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -14334,9 +14334,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14397,9 +14397,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17370,8 +17370,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -17561,41 +17561,41 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17632,9 +17632,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17669,9 +17669,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17706,9 +17706,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17743,9 +17743,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17780,9 +17780,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -18253,8 +18253,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -18763,8 +18763,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -18779,7 +18779,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19356,8 +19356,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -19372,7 +19372,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -20359,8 +20359,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -20412,9 +20412,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20449,9 +20449,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20816,8 +20816,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -21414,8 +21414,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -21430,7 +21430,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21450,9 +21450,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21475,9 +21475,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21500,9 +21500,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21525,9 +21525,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -22185,8 +22185,8 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -22201,7 +22201,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -22232,15 +22232,15 @@ get manualApprovals(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -22273,15 +22273,15 @@ get manualApprovals(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -23245,8 +23245,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -23298,9 +23298,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -23335,9 +23335,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23701,8 +23701,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -24617,8 +24617,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -24670,9 +24670,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24707,9 +24707,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25073,8 +25073,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -25988,8 +25988,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -26041,9 +26041,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26078,9 +26078,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26444,8 +26444,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -26896,8 +26896,8 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -26916,7 +26916,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -26947,15 +26947,15 @@ get endpoints(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27257,8 +27257,8 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -28082,8 +28082,8 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -28098,7 +28098,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28148,9 +28148,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -29064,8 +29064,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -29080,7 +29080,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     
@@ -29114,41 +29114,41 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29975,8 +29975,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -29991,7 +29991,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     
@@ -30025,41 +30025,41 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30837,8 +30837,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -30853,7 +30853,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -30902,15 +30902,15 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30932,9 +30932,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30957,9 +30957,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30982,9 +30982,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31729,8 +31729,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -31788,9 +31788,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31813,9 +31813,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -32230,8 +32230,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -32570,8 +32570,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -32905,8 +32905,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -38520,8 +38520,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -38597,9 +38597,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38634,9 +38634,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38691,17 +38691,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38740,17 +38740,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38787,9 +38787,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38824,9 +38824,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38861,9 +38861,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38898,9 +38898,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38935,9 +38935,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38972,9 +38972,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38997,9 +38997,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -39108,41 +39108,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39181,41 +39181,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39252,9 +39252,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40079,8 +40079,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -40426,8 +40426,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -41431,8 +41431,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -41484,9 +41484,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -41547,9 +41547,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -42080,8 +42080,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -42509,8 +42509,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -42843,8 +42843,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -43183,8 +43183,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -47054,8 +47054,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -47137,9 +47137,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -47174,9 +47174,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -47211,9 +47211,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -47251,18 +47251,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -47299,9 +47299,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -47336,9 +47336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -47373,9 +47373,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -47410,9 +47410,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -47447,9 +47447,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -47484,9 +47484,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -47521,9 +47521,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -47558,9 +47558,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48999,8 +48999,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -49056,9 +49056,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -49093,9 +49093,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -49130,9 +49130,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -49506,8 +49506,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -49840,8 +49840,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -50172,8 +50172,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -50973,8 +50973,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -50989,7 +50989,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -51020,15 +51020,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -51061,15 +51061,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -51102,15 +51102,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -51143,15 +51143,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -51184,15 +51184,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -51225,15 +51225,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -51686,8 +51686,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -52021,8 +52021,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -52357,8 +52357,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -57972,8 +57972,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -58049,9 +58049,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -58086,9 +58086,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -58143,17 +58143,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58192,17 +58192,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58239,9 +58239,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -58276,9 +58276,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -58313,9 +58313,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -58350,9 +58350,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -58387,9 +58387,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -58424,9 +58424,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -58449,9 +58449,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -58560,41 +58560,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58633,41 +58633,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58704,9 +58704,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -60510,8 +60510,8 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -60534,7 +60534,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -60565,15 +60565,15 @@ get names(): ((string | LanguageString))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)));
+        : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -60724,18 +60724,18 @@ get names(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61209,8 +61209,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -61546,8 +61546,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -61881,8 +61881,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -62219,8 +62219,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -62553,8 +62553,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -62887,8 +62887,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -63221,8 +63221,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -63553,8 +63553,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -63851,8 +63851,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -64186,8 +64186,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -65193,8 +65193,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -65246,9 +65246,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -65309,9 +65309,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -66003,8 +66003,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -66059,18 +66059,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -66803,8 +66803,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -66859,18 +66859,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72529,8 +72529,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -72606,9 +72606,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -72643,9 +72643,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -72700,17 +72700,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72749,17 +72749,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72796,9 +72796,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -72833,9 +72833,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -72870,9 +72870,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -72907,9 +72907,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -72944,9 +72944,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -72981,9 +72981,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -73006,9 +73006,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -73117,41 +73117,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73190,41 +73190,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73261,9 +73261,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -74090,8 +74090,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -79705,8 +79705,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -79782,9 +79782,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -79819,9 +79819,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -79876,17 +79876,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79925,17 +79925,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79972,9 +79972,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -80009,9 +80009,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -80046,9 +80046,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -80083,9 +80083,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -80120,9 +80120,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -80157,9 +80157,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -80182,9 +80182,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -80293,41 +80293,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -80366,41 +80366,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -80437,9 +80437,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -81722,8 +81722,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -81868,15 +81868,15 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))
+        : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl))) : undefined
+        : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -82607,8 +82607,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -82660,9 +82660,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -84290,8 +84290,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -84343,9 +84343,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -84380,9 +84380,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -84466,9 +84466,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -84529,9 +84529,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -84990,8 +84990,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -85324,8 +85324,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -86850,8 +86850,8 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -86903,9 +86903,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -86940,9 +86940,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -86977,9 +86977,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -87367,8 +87367,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -92982,8 +92982,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -93059,9 +93059,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -93096,9 +93096,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -93153,17 +93153,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93202,17 +93202,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93249,9 +93249,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -93286,9 +93286,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -93323,9 +93323,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -93360,9 +93360,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -93397,9 +93397,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -93434,9 +93434,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -93459,9 +93459,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -93570,41 +93570,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93643,41 +93643,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -93714,9 +93714,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ||
           values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"] as string, options.baseUrl)
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values[\\"@id\\"] as string, options.baseUrl)) }
+        : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -94759,8 +94759,8 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -94775,7 +94775,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"], options.baseUrl) ? new URL(values[\\"@id\\"], options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -95191,8 +95191,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -95525,8 +95525,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -96075,8 +96075,8 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -96510,8 +96510,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -96849,8 +96849,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -97186,8 +97186,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -97523,8 +97523,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {
@@ -97856,8 +97856,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string)) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"] as string) };
+    if (options.baseUrl == null && values[\\"@id\\"] != null && !values[\\"@id\\"].startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"])) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
   if (\\"@type\\" in values) {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10890,27 +10890,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -10920,43 +10902,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10982,27 +10937,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11011,68 +10948,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11098,43 +10990,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -11182,27 +11047,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11212,30 +11059,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11307,27 +11136,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11337,30 +11148,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11391,16 +11184,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })(),
+            baseUrl: options.baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11417,43 +11201,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11482,16 +11239,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })(),
+            baseUrl: options.baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11508,43 +11256,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11568,27 +11289,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11598,30 +11301,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11647,27 +11332,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11677,30 +11344,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11726,27 +11375,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -11756,30 +11387,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11827,43 +11440,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11887,43 +11473,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11947,43 +11506,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -12007,43 +11539,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -12113,27 +11618,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -12143,30 +11630,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -12225,40 +11694,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], options.baseUrl) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -12284,43 +11726,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -12344,43 +11759,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -12404,43 +11792,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -12464,43 +11825,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -12575,16 +11909,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -12608,43 +11933,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -12665,16 +11963,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -12706,27 +11995,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12749,43 +12020,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12809,43 +12053,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12869,43 +12086,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -15151,43 +14341,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -15237,43 +14400,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -18485,27 +17621,9 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -18514,68 +17632,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -18601,43 +17674,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -18661,43 +17707,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -18721,43 +17740,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -18781,43 +17773,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -18841,43 +17806,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -21518,43 +20456,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -21578,43 +20489,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -22617,16 +21501,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -22647,16 +21522,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -22677,16 +21543,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -22707,16 +21564,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -23422,27 +22270,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -23473,27 +22303,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -24512,43 +23324,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24572,43 +23357,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25946,43 +24704,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26006,43 +24737,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -27379,43 +26083,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -27439,43 +26116,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -28346,27 +26996,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -29554,43 +28186,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -30549,27 +29154,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -30578,68 +29165,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -31511,27 +30053,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -31540,68 +30064,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -32445,27 +30924,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -32485,16 +30946,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -32515,16 +30967,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -32545,16 +30988,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -33359,16 +31793,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -33389,16 +31814,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -40266,43 +38682,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -40326,43 +38715,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -40404,27 +38766,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -40433,29 +38777,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -40481,27 +38807,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -40510,29 +38818,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -40558,43 +38848,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -40618,43 +38881,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -40678,43 +38914,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -40738,43 +38947,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -40798,43 +38980,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -40858,43 +39013,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -40915,16 +39043,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -41020,27 +39139,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -41049,68 +39150,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -41136,27 +39192,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -41165,68 +39203,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -41252,43 +39245,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -43526,43 +41492,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -43612,43 +41551,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -49300,43 +47212,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -49360,43 +47245,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -49420,43 +47278,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -49480,27 +47311,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -49510,30 +47323,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -49559,43 +47354,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -49619,43 +47387,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -49679,43 +47420,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -49739,43 +47453,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -49799,43 +47486,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -49859,43 +47519,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -49919,43 +47552,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -49979,43 +47585,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -51518,43 +49097,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -51578,43 +49130,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -51638,43 +49163,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -53572,27 +51070,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -53623,27 +51103,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -53674,27 +51136,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -53725,27 +51169,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -53776,27 +51202,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -53827,27 +51235,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -60749,43 +58139,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -60809,43 +58172,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -60887,27 +58223,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -60916,29 +58234,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60964,27 +58264,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -60993,29 +58275,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61041,43 +58305,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -61101,43 +58338,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -61161,43 +58371,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -61221,43 +58404,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -61281,43 +58437,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -61341,43 +58470,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -61398,16 +58500,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -61503,27 +58596,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -61532,68 +58607,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61619,27 +58649,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -61648,68 +58660,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -61735,43 +58702,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -63636,27 +60576,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v[\\"@id\\"], options.baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -63793,27 +60715,9 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -63823,30 +60727,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -68389,43 +65275,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -68475,43 +65334,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -69253,27 +66085,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -69283,30 +66097,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -70089,27 +66885,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -70119,30 +66897,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -75955,43 +72715,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -76015,43 +72748,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -76093,27 +72799,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76122,29 +72810,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76170,27 +72840,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76199,29 +72851,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76247,43 +72881,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -76307,43 +72914,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -76367,43 +72947,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -76427,43 +72980,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -76487,43 +73013,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -76547,43 +73046,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -76604,16 +73076,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -76709,27 +73172,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76738,68 +73183,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76825,27 +73225,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -76854,68 +73236,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -76941,43 +73278,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -83576,43 +79886,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -83636,43 +79919,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -83714,27 +79970,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -83743,29 +79981,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -83791,27 +80011,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -83820,29 +80022,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -83868,43 +80052,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -83928,43 +80085,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -83988,43 +80118,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -84048,43 +80151,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -84108,43 +80184,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -84168,43 +80217,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -84225,16 +80247,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -84330,27 +80343,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -84359,68 +80354,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -84446,27 +80396,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -84475,68 +80407,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -84562,43 +80449,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -86028,27 +81888,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v[\\"@id\\"]) && options.baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) : undefined
+          : new URL(v[\\"@id\\"], options.baseUrl) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -86829,43 +82671,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -88558,43 +84373,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -88618,43 +84406,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -88727,43 +84488,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -88813,43 +84547,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -91244,43 +86951,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -91304,43 +86984,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -91364,43 +87017,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -97560,43 +93186,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -97620,43 +93219,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -97698,27 +93270,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -97727,29 +93281,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -97775,27 +93311,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -97804,29 +93322,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -97852,43 +93352,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -97912,43 +93385,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -97972,43 +93418,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -98032,43 +93451,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -98092,43 +93484,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -98152,43 +93517,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -98209,16 +93547,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -98314,27 +93643,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -98343,68 +93654,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -98430,27 +93696,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
@@ -98459,68 +93707,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -98546,43 +93749,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v[\\"@id\\"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
-              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values[\\"@id\\"], options.baseUrl);
-          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10615,7 +10615,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     
@@ -18469,7 +18469,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19060,7 +19060,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -21114,7 +21114,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21867,7 +21867,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -26558,7 +26558,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -27735,7 +27735,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28709,7 +28709,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     
@@ -29596,7 +29596,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     
@@ -30436,7 +30436,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -50391,7 +50391,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -59774,7 +59774,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -93635,7 +93635,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10342,9 +10342,14 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -10643,16 +10648,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10689,23 +10694,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10740,7 +10745,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10800,12 +10805,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10889,12 +10894,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10925,7 +10930,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: _baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10951,7 +10956,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10980,7 +10985,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: _baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11006,7 +11011,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11042,12 +11047,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11085,12 +11090,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11128,12 +11133,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11190,7 +11195,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11223,7 +11228,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11256,7 +11261,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11289,7 +11294,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11371,12 +11376,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11435,13 +11440,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], _baseUrl) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11476,7 +11481,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11509,7 +11514,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11542,7 +11547,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11575,7 +11580,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11650,7 +11655,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11683,7 +11688,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11704,7 +11709,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11736,9 +11741,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11770,7 +11775,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11803,7 +11808,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11836,7 +11841,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13014,9 +13019,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -14020,9 +14030,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -14071,7 +14086,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14130,7 +14145,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17077,9 +17092,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -17266,23 +17286,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17317,7 +17337,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17350,7 +17370,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17383,7 +17403,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17416,7 +17436,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17449,7 +17469,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17920,9 +17940,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -18423,9 +18448,14 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -19009,9 +19039,14 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -20008,9 +20043,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -20059,7 +20099,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20092,7 +20132,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20457,9 +20497,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21048,9 +21093,14 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21082,7 +21132,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21103,7 +21153,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21124,7 +21174,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21145,7 +21195,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21796,9 +21846,14 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21841,9 +21896,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21874,9 +21929,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22836,9 +22891,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -22887,7 +22947,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22920,7 +22980,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23284,9 +23344,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -24196,9 +24261,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -24247,7 +24317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24280,7 +24350,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24644,9 +24714,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25555,9 +25630,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25606,7 +25686,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25639,7 +25719,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26003,9 +26083,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26448,9 +26533,14 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26497,9 +26587,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26801,9 +26891,14 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27619,9 +27714,14 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27683,7 +27783,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28588,9 +28688,14 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -28636,23 +28741,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29470,9 +29575,14 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -29518,23 +29628,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30305,9 +30415,14 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -30368,9 +30483,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30390,7 +30505,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30411,7 +30526,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30432,7 +30547,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31177,9 +31292,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -31234,7 +31354,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31255,7 +31375,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31670,9 +31790,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32010,9 +32135,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32345,9 +32475,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -37926,9 +38061,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -38001,7 +38141,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38034,7 +38174,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38087,11 +38227,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38128,11 +38268,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38167,7 +38307,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38200,7 +38340,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38233,7 +38373,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38266,7 +38406,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38299,7 +38439,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38332,7 +38472,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38353,7 +38493,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38460,23 +38600,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38513,23 +38653,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38564,7 +38704,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39389,9 +39529,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -39736,9 +39881,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40737,9 +40887,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40788,7 +40943,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40847,7 +41002,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41378,9 +41533,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -41807,9 +41967,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42141,9 +42306,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42481,9 +42651,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -46328,9 +46503,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -46409,7 +46589,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46442,7 +46622,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46475,7 +46655,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46511,12 +46691,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46551,7 +46731,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46584,7 +46764,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46617,7 +46797,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46650,7 +46830,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46683,7 +46863,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46716,7 +46896,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46749,7 +46929,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46782,7 +46962,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48215,9 +48395,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -48270,7 +48455,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48303,7 +48488,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48336,7 +48521,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48710,9 +48895,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49044,9 +49234,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49376,9 +49571,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50170,9 +50370,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50215,9 +50420,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50248,9 +50453,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50281,9 +50486,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50314,9 +50519,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50347,9 +50552,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50380,9 +50585,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50835,9 +51040,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51170,9 +51380,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51506,9 +51721,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -57087,9 +57307,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -57162,7 +57387,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57195,7 +57420,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57248,11 +57473,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57289,11 +57514,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57328,7 +57553,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57361,7 +57586,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57394,7 +57619,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57427,7 +57652,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57460,7 +57685,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57493,7 +57718,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57514,7 +57739,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57621,23 +57846,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57674,23 +57899,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57725,7 +57950,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59520,9 +59745,14 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -59573,9 +59803,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], _baseUrl);
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59724,12 +59954,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60203,9 +60433,14 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -60540,9 +60775,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -60875,9 +61115,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61213,9 +61458,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61547,9 +61797,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61881,9 +62136,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62215,9 +62475,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62547,9 +62812,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62845,9 +63115,14 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63180,9 +63455,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -64183,9 +64463,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -64234,7 +64519,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64293,7 +64578,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64983,9 +65268,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -65037,12 +65327,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65773,9 +66063,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -65827,12 +66122,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71457,9 +71752,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -71532,7 +71832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71565,7 +71865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71618,11 +71918,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71659,11 +71959,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71698,7 +71998,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71731,7 +72031,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71764,7 +72064,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71797,7 +72097,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71830,7 +72130,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71863,7 +72163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71884,7 +72184,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71991,23 +72291,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72044,23 +72344,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72095,7 +72395,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72922,9 +73222,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -78503,9 +78808,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -78578,7 +78888,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78611,7 +78921,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78664,11 +78974,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78705,11 +79015,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78744,7 +79054,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78777,7 +79087,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78810,7 +79120,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78843,7 +79153,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78876,7 +79186,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78909,7 +79219,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78930,7 +79240,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79037,23 +79347,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79090,23 +79400,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79141,7 +79451,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80424,9 +80734,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -80568,9 +80883,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && _baseUrl
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
+          : new URL(v[\\"@id\\"], _baseUrl) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81299,9 +81614,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -81350,7 +81670,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82970,9 +83290,14 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -83021,7 +83346,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83054,7 +83379,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83136,7 +83461,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83195,7 +83520,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83654,9 +83979,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -83988,9 +84318,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -85504,9 +85839,14 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -85555,7 +85895,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85588,7 +85928,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85621,7 +85961,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86009,9 +86349,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -91590,9 +91935,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -91665,7 +92015,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91698,7 +92048,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91751,11 +92101,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91792,11 +92142,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91831,7 +92181,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91864,7 +92214,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91897,7 +92247,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91930,7 +92280,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91963,7 +92313,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91996,7 +92346,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92017,7 +92367,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92124,23 +92474,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92177,23 +92527,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92228,7 +92578,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93264,9 +93614,14 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -93696,9 +94051,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94030,9 +94390,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94580,9 +94945,14 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95015,9 +95385,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95354,9 +95729,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95691,9 +96071,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96028,9 +96413,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96361,9 +96751,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
-      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
+    const _resolvedUrl =
+      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? new URL(values[\\"@id\\"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -2344,8 +2344,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#attachment_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -2604,8 +2609,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#attribution_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -2706,8 +2716,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#attribution_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -2929,8 +2944,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#audience_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -3030,8 +3050,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#audience_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3297,8 +3322,13 @@ get contents(): ((string | LanguageString))[] {
       
               v = await this.#context_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3571,8 +3601,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#generator_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3816,8 +3851,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -3918,8 +3958,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4163,8 +4208,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#image_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4265,8 +4315,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4497,8 +4552,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#replyTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4598,8 +4658,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#replyTarget_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4830,8 +4895,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#location_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4931,8 +5001,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#location_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -5162,8 +5237,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#preview_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5262,8 +5342,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#preview_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -5498,8 +5583,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#replies_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5726,8 +5816,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#shares_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5954,8 +6049,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#likes_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6176,8 +6276,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#emojiReactions_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6450,8 +6555,13 @@ get summaries(): ((string | LanguageString))[] {
       
               v = await this.#tag_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -6707,8 +6817,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#to_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6808,8 +6923,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#to_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7031,8 +7151,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#bto_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7132,8 +7257,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#bto_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7355,8 +7485,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#cc_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7456,8 +7591,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#cc_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7679,8 +7819,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#bcc_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7780,8 +7925,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#bcc_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -8066,8 +8216,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#proof_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8166,8 +8321,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#proof_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -8428,8 +8588,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#likeAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8650,8 +8815,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#replyAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8872,8 +9042,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#announceAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -10715,17 +10890,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10735,28 +10920,43 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10782,17 +10982,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10801,43 +11011,68 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10863,28 +11098,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10932,17 +11182,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10952,20 +11212,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11037,17 +11307,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11057,20 +11337,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11101,11 +11391,16 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })(),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11122,28 +11417,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11172,11 +11482,16 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })(),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11193,28 +11508,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11238,17 +11568,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11258,20 +11598,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11297,17 +11647,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11317,20 +11677,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11356,17 +11726,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11376,20 +11756,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11437,28 +11827,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11482,28 +11887,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11527,28 +11947,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11572,28 +12007,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11663,17 +12113,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11683,20 +12143,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11755,25 +12225,40 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11799,28 +12284,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11844,28 +12344,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11889,28 +12404,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11934,28 +12464,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -12030,11 +12575,16 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -12058,28 +12608,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -12100,11 +12665,16 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -12136,17 +12706,27 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12169,28 +12749,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12214,28 +12809,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12259,28 +12869,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13901,8 +14526,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -14146,8 +14776,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -14516,28 +15151,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14587,28 +15237,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -15557,8 +16222,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#actor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -15659,8 +16329,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#actor_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -15883,8 +16558,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#object_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -15985,8 +16665,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#object_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16212,8 +16897,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#target_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16317,8 +17007,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#target_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16541,8 +17236,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#result_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16643,8 +17343,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#result_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16868,8 +17573,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#origin_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16971,8 +17681,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#origin_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -17194,8 +17909,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#instrument_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -17295,8 +18015,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#instrument_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -17760,17 +18485,27 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -17779,43 +18514,68 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17841,28 +18601,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17886,28 +18661,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17931,28 +18721,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17976,28 +18781,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -18021,28 +18841,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -20127,8 +20962,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -20348,8 +21188,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -20673,28 +21518,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20718,28 +21578,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -21742,11 +22617,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21767,11 +22647,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21792,11 +22677,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21817,11 +22707,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -22527,17 +23422,27 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -22568,17 +23473,27 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -23041,8 +23956,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -23262,8 +24182,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -23587,28 +24512,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -23632,28 +24572,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24435,8 +25390,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -24656,8 +25616,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -24981,28 +25946,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25026,28 +26006,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25828,8 +26823,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -26049,8 +27049,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -26374,28 +27379,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26419,28 +27439,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -27311,17 +28346,27 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -28509,28 +29554,43 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -29166,8 +30226,13 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       
             v = await this.#owner_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -29484,17 +30549,27 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -29503,43 +30578,68 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30081,8 +31181,13 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       
             v = await this.#controller_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -30406,17 +31511,27 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -30425,43 +31540,68 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -31305,17 +32445,27 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -31335,11 +32485,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -31360,11 +32515,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -31385,11 +32545,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -32194,11 +33359,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -32219,11 +33389,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -34601,8 +35776,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -34700,8 +35880,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -34925,8 +36110,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35028,8 +36218,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -35290,8 +36485,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35529,8 +36729,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35754,8 +36959,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35982,8 +37192,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36208,8 +37423,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36432,8 +37652,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36656,8 +37881,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36878,8 +38108,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -37210,8 +38445,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37470,8 +38710,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37573,8 +38818,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -37798,8 +39048,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37901,8 +39156,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -39006,28 +40266,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -39051,28 +40326,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -39114,17 +40404,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39133,19 +40433,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39171,17 +40481,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39190,19 +40510,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39228,28 +40558,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -39273,28 +40618,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -39318,28 +40678,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -39363,28 +40738,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -39408,28 +40798,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -39453,28 +40858,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -39495,11 +40915,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -39595,17 +41020,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39614,43 +41049,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39676,17 +41136,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39695,43 +41165,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -39757,28 +41252,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -41391,8 +42901,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -41636,8 +43151,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -42006,28 +43526,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -42077,28 +43612,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -44502,8 +46052,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#current_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -44724,8 +46279,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#first_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -44946,8 +46506,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#last_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45178,8 +46743,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -45400,8 +46970,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#likesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45621,8 +47196,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#sharesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45842,8 +47422,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#repliesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46063,8 +47648,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#inboxOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46284,8 +47874,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#outboxOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46505,8 +48100,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#followersOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46726,8 +48326,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#followingOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46947,8 +48552,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#likedOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -47690,28 +49300,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -47735,28 +49360,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -47780,28 +49420,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -47825,17 +49480,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -47845,20 +49510,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -47884,28 +49559,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -47929,28 +49619,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -47974,28 +49679,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -48019,28 +49739,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -48064,28 +49799,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -48109,28 +49859,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -48154,28 +49919,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -48199,28 +49979,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48903,8 +50698,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#partOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49123,8 +50923,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#next_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49344,8 +51149,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#prev_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49708,28 +51518,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -49753,28 +51578,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -49798,28 +51638,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -51717,17 +53572,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -51758,17 +53623,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -51799,17 +53674,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -51840,17 +53725,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -51881,17 +53776,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -51922,17 +53827,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -54344,8 +56259,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -54443,8 +56363,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -54668,8 +56593,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -54771,8 +56701,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -55033,8 +56968,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55272,8 +57212,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55497,8 +57442,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55725,8 +57675,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55951,8 +57906,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56175,8 +58135,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56399,8 +58364,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56621,8 +58591,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -56953,8 +58928,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57213,8 +59193,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57316,8 +59301,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -57541,8 +59531,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57644,8 +59639,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -58749,28 +60749,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -58794,28 +60809,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -58857,17 +60887,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -58876,19 +60916,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58914,17 +60964,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -58933,19 +60993,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -58971,28 +61041,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -59016,28 +61101,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -59061,28 +61161,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -59106,28 +61221,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -59151,28 +61281,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -59196,28 +61341,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -59238,11 +61398,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -59338,17 +61503,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -59357,43 +61532,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -59419,17 +61619,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -59438,43 +61648,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -59500,28 +61735,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -60868,8 +63118,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#preview_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -61381,17 +63636,27 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -61528,17 +63793,27 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -61548,20 +63823,30 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65479,8 +67764,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -65724,8 +68014,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -66094,28 +68389,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -66165,28 +68475,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -66631,8 +68956,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -66923,17 +69253,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -66943,20 +69283,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -67393,8 +69743,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -67734,17 +70089,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -67754,20 +70119,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -69090,8 +71465,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -69189,8 +71569,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -69414,8 +71799,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -69517,8 +71907,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -69779,8 +72174,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70018,8 +72418,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70243,8 +72648,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70471,8 +72881,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70697,8 +73112,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70921,8 +73341,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71145,8 +73570,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71367,8 +73797,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -71699,8 +74134,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71959,8 +74399,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -72062,8 +74507,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -72287,8 +74737,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -72390,8 +74845,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -73495,28 +75955,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -73540,28 +76015,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -73603,17 +76093,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -73622,19 +76122,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73660,17 +76170,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -73679,19 +76199,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -73717,28 +76247,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -73762,28 +76307,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -73807,28 +76367,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -73852,28 +76427,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -73897,28 +76487,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -73942,28 +76547,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -73984,11 +76604,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -74084,17 +76709,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -74103,43 +76738,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -74165,17 +76825,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -74184,43 +76854,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -74246,28 +76941,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -76376,8 +79086,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -76475,8 +79190,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -76700,8 +79420,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -76803,8 +79528,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -77065,8 +79795,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77304,8 +80039,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77529,8 +80269,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77757,8 +80502,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77983,8 +80733,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78207,8 +80962,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78431,8 +81191,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78653,8 +81418,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -78985,8 +81755,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79245,8 +82020,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79348,8 +82128,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -79573,8 +82358,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79676,8 +82466,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -80781,28 +83576,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -80826,28 +83636,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -80889,17 +83714,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -80908,19 +83743,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -80946,17 +83791,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -80965,19 +83820,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -81003,28 +83868,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -81048,28 +83928,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -81093,28 +83988,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -81138,28 +84048,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -81183,28 +84108,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -81228,28 +84168,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -81270,11 +84225,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -81370,17 +84330,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -81389,43 +84359,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -81451,17 +84446,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -81470,43 +84475,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -81532,28 +84562,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -82983,17 +86028,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
+          : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -83479,8 +86534,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#describes_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -83769,28 +86829,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -84386,8 +87461,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
               v = await this.#exclusiveOption_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -84611,8 +87691,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
               v = await this.#inclusiveOption_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -84865,8 +87950,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -85110,8 +88200,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -85463,28 +88558,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -85508,28 +88618,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -85602,28 +88727,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -85673,28 +88813,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -87056,8 +90211,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#subject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87277,8 +90437,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#object_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87377,8 +90542,13 @@ relationships?: (Object | URL)[];}
       
               v = await this.#object_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -87601,8 +90771,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#relationship_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87703,8 +90878,13 @@ relationships?: (Object | URL)[];}
       
               v = await this.#relationship_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -88064,28 +91244,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -88109,28 +91304,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -88154,28 +91364,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -89845,8 +93070,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -89944,8 +93174,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -90169,8 +93404,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90272,8 +93512,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -90534,8 +93779,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90773,8 +94023,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90998,8 +94253,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91226,8 +94486,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91452,8 +94717,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91676,8 +94946,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91900,8 +95175,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92122,8 +95402,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -92454,8 +95739,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92714,8 +96004,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92817,8 +96112,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -93042,8 +96342,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -93145,8 +96450,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === \\"http:\\" ||
+                      this.id.protocol === \\"https:\\")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -94250,28 +97560,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -94295,28 +97620,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -94358,17 +97698,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94377,19 +97727,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -94415,17 +97775,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94434,19 +97804,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -94472,28 +97852,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -94517,28 +97912,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -94562,28 +97972,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -94607,28 +98032,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -94652,28 +98092,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -94697,28 +98152,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -94739,11 +98209,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -94839,17 +98314,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94858,43 +98343,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -94920,17 +98430,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94939,43 +98459,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -95001,28 +98546,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })()) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)))
+            : new URL(v[\\"@id\\"], (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ||
-          values[\\"@id\\"].startsWith(\\"_:\\") ||
-          !URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values[\\"@id\\"] == null || values[\\"@id\\"].startsWith(\\"_:\\") ||
+              !URL.canParse(values[\\"@id\\"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values[\\"@id\\"], options.baseUrl);
+          return id.protocol === \\"http:\\" || id.protocol === \\"https:\\"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -26,6 +26,8 @@ import {
 } from \\"@fedify/vocab-runtime/temporal\\";
 
 
+import * as _ppM0 from \\"./preprocessors.ts\\";
+
 /** Describes an object of any kind. The Object type serves as the base type for
  * most of the other kinds of objects defined in the Activity Vocabulary,
  * including other Core types such as {@link Activity},
@@ -3668,7 +3670,6 @@ get names(): ((string | LanguageString))[] {
         for (const _pp_obj of _expanded) {
       
           {
-            const _ppM0 = await import(\\"./preprocessors.ts\\");
             const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
               documentLoader,
               contextLoader,
@@ -4002,7 +4003,6 @@ get names(): ((string | LanguageString))[] {
         for (const _pp_obj of _expanded) {
       
           {
-            const _ppM0 = await import(\\"./preprocessors.ts\\");
             const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
               documentLoader,
               contextLoader,
@@ -10600,7 +10600,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10781,12 +10781,11 @@ get urls(): ((URL | Link))[] {
         let _handled: Image | undefined;
       
         if (_handled === undefined) {
-          const _ppM0 = await import(\\"./preprocessors.ts\\");
           const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10812,7 +10811,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10837,12 +10836,11 @@ get urls(): ((URL | Link))[] {
         let _handled: Image | undefined;
       
         if (_handled === undefined) {
-          const _ppM0 = await import(\\"./preprocessors.ts\\");
           const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10868,7 +10866,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11052,7 +11050,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11085,7 +11083,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11118,7 +11116,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11151,7 +11149,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11338,7 +11336,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11371,7 +11369,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11404,7 +11402,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11437,7 +11435,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11512,7 +11510,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11545,7 +11543,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11566,7 +11564,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11598,9 +11596,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11632,7 +11630,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11665,7 +11663,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11698,7 +11696,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13925,7 +13923,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -13984,7 +13982,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17123,7 +17121,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17156,7 +17154,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17189,7 +17187,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17222,7 +17220,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17255,7 +17253,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19857,7 +19855,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -19890,7 +19888,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20880,7 +20878,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -20901,7 +20899,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -20922,7 +20920,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -20943,7 +20941,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21639,9 +21637,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21672,9 +21670,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22677,7 +22675,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22710,7 +22708,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24029,7 +24027,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24062,7 +24060,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25380,7 +25378,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25413,7 +25411,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26271,9 +26269,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27457,7 +27455,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -30134,9 +30132,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30156,7 +30154,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30177,7 +30175,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30198,7 +30196,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31000,7 +30998,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31021,7 +31019,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37699,7 +37697,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37732,7 +37730,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37865,7 +37863,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -37898,7 +37896,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -37931,7 +37929,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -37964,7 +37962,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -37997,7 +37995,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38030,7 +38028,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38051,7 +38049,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38262,7 +38260,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40478,7 +40476,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40537,7 +40535,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46051,7 +46049,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46084,7 +46082,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46117,7 +46115,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46193,7 +46191,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46226,7 +46224,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46259,7 +46257,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46292,7 +46290,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46325,7 +46323,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46358,7 +46356,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46391,7 +46389,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46424,7 +46422,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47900,7 +47898,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -47933,7 +47931,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -47966,7 +47964,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -49845,9 +49843,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -49878,9 +49876,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -49911,9 +49909,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -49944,9 +49942,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -49977,9 +49975,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50010,9 +50008,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56724,7 +56722,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56757,7 +56755,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -56890,7 +56888,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -56923,7 +56921,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -56956,7 +56954,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -56989,7 +56987,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57022,7 +57020,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57055,7 +57053,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57076,7 +57074,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57287,7 +57285,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59131,9 +59129,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -63784,7 +63782,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -63843,7 +63841,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -71006,7 +71004,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71039,7 +71037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71172,7 +71170,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71205,7 +71203,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71238,7 +71236,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71271,7 +71269,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71304,7 +71302,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71337,7 +71335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71358,7 +71356,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71569,7 +71567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -77984,7 +77982,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78017,7 +78015,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78150,7 +78148,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78183,7 +78181,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78216,7 +78214,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78249,7 +78247,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78282,7 +78280,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78315,7 +78313,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78336,7 +78334,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78547,7 +78545,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80752,7 +80750,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82407,7 +82405,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82440,7 +82438,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82522,7 +82520,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82581,7 +82579,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -84921,7 +84919,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -84954,7 +84952,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -84987,7 +84985,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -90963,7 +90961,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -90996,7 +90994,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91129,7 +91127,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91162,7 +91160,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91195,7 +91193,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91228,7 +91226,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91261,7 +91259,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91294,7 +91292,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91315,7 +91313,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91526,7 +91524,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"]) ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10292,7 +10292,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -10593,16 +10593,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10639,23 +10639,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10690,7 +10690,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10750,12 +10750,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10839,12 +10839,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10875,7 +10875,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10901,7 +10901,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10930,7 +10930,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10956,7 +10956,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10992,12 +10992,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11035,12 +11035,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11078,12 +11078,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11140,7 +11140,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11173,7 +11173,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11206,7 +11206,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11239,7 +11239,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11321,12 +11321,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11385,13 +11385,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11426,7 +11426,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11459,7 +11459,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11492,7 +11492,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11525,7 +11525,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11600,7 +11600,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11633,7 +11633,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11654,7 +11654,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11686,9 +11686,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11720,7 +11720,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11753,7 +11753,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11786,7 +11786,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -12964,7 +12964,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -13966,7 +13966,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -14017,7 +14017,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14076,7 +14076,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -16999,7 +16999,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -17188,23 +17188,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17239,7 +17239,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17272,7 +17272,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17305,7 +17305,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17338,7 +17338,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17371,7 +17371,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17842,7 +17842,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18345,7 +18345,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18931,7 +18931,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19926,7 +19926,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -19977,7 +19977,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20010,7 +20010,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20375,7 +20375,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20966,7 +20966,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21000,7 +21000,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21021,7 +21021,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21042,7 +21042,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21063,7 +21063,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21714,7 +21714,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21759,9 +21759,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21792,9 +21792,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22750,7 +22750,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -22801,7 +22801,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22834,7 +22834,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23198,7 +23198,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24106,7 +24106,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24157,7 +24157,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24190,7 +24190,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24554,7 +24554,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25461,7 +25461,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25512,7 +25512,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25545,7 +25545,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25909,7 +25909,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26354,7 +26354,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26403,9 +26403,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26707,7 +26707,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27525,7 +27525,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27589,7 +27589,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28492,7 +28492,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -28540,23 +28540,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29372,7 +29372,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -29420,23 +29420,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30207,7 +30207,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30270,9 +30270,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30292,7 +30292,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30313,7 +30313,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30334,7 +30334,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31079,7 +31079,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31136,7 +31136,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31157,7 +31157,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31572,7 +31572,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31912,7 +31912,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32247,7 +32247,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37794,7 +37794,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37869,7 +37869,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37902,7 +37902,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37955,11 +37955,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37996,11 +37996,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38035,7 +38035,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38068,7 +38068,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38101,7 +38101,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38134,7 +38134,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38167,7 +38167,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38200,7 +38200,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38221,7 +38221,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38328,23 +38328,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38381,23 +38381,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38432,7 +38432,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39257,7 +39257,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39604,7 +39604,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40601,7 +40601,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40652,7 +40652,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40711,7 +40711,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41242,7 +41242,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41671,7 +41671,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42005,7 +42005,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42345,7 +42345,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46168,7 +46168,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46249,7 +46249,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46282,7 +46282,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46315,7 +46315,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46351,12 +46351,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46391,7 +46391,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46424,7 +46424,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46457,7 +46457,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46490,7 +46490,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46523,7 +46523,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46556,7 +46556,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46589,7 +46589,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46622,7 +46622,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48049,7 +48049,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48104,7 +48104,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48137,7 +48137,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48170,7 +48170,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48544,7 +48544,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48878,7 +48878,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49210,7 +49210,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50004,7 +50004,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50049,9 +50049,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50082,9 +50082,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50115,9 +50115,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50148,9 +50148,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50181,9 +50181,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50214,9 +50214,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50669,7 +50669,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51004,7 +51004,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51340,7 +51340,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56887,7 +56887,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56962,7 +56962,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56995,7 +56995,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57048,11 +57048,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57089,11 +57089,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57128,7 +57128,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57161,7 +57161,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57194,7 +57194,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57227,7 +57227,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57260,7 +57260,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57293,7 +57293,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57314,7 +57314,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57421,23 +57421,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57474,23 +57474,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57525,7 +57525,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59318,7 +59318,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59371,9 +59371,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59522,12 +59522,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60001,7 +60001,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60338,7 +60338,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60673,7 +60673,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61011,7 +61011,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61345,7 +61345,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61679,7 +61679,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62013,7 +62013,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62345,7 +62345,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62643,7 +62643,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62978,7 +62978,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63977,7 +63977,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64028,7 +64028,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64087,7 +64087,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64775,7 +64775,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64829,12 +64829,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65563,7 +65563,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65617,12 +65617,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71213,7 +71213,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -71288,7 +71288,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71321,7 +71321,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71374,11 +71374,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71415,11 +71415,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71454,7 +71454,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71487,7 +71487,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71520,7 +71520,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71553,7 +71553,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71586,7 +71586,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71619,7 +71619,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71640,7 +71640,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71747,23 +71747,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71800,23 +71800,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71851,7 +71851,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72678,7 +72678,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78225,7 +78225,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78300,7 +78300,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78333,7 +78333,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78386,11 +78386,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78427,11 +78427,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78466,7 +78466,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78499,7 +78499,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78532,7 +78532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78565,7 +78565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78598,7 +78598,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78631,7 +78631,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78652,7 +78652,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78759,23 +78759,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78812,23 +78812,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78863,7 +78863,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80146,7 +80146,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -80290,9 +80290,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81019,7 +81019,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -81070,7 +81070,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82682,7 +82682,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -82733,7 +82733,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82766,7 +82766,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82848,7 +82848,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82907,7 +82907,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83366,7 +83366,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83700,7 +83700,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85206,7 +85206,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85257,7 +85257,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85290,7 +85290,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85323,7 +85323,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -85711,7 +85711,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91258,7 +91258,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91333,7 +91333,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91366,7 +91366,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91419,11 +91419,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91460,11 +91460,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91499,7 +91499,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91532,7 +91532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91565,7 +91565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91598,7 +91598,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91631,7 +91631,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91664,7 +91664,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91685,7 +91685,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91792,23 +91792,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91845,23 +91845,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91896,7 +91896,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -92932,7 +92932,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93364,7 +93364,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93698,7 +93698,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94248,7 +94248,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94683,7 +94683,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95022,7 +95022,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95359,7 +95359,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95696,7 +95696,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -96029,7 +96029,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10715,9 +10715,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -10774,9 +10782,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -10847,9 +10863,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -10908,9 +10932,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11005,9 +11037,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11082,9 +11122,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11145,9 +11193,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11182,9 +11238,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11233,9 +11297,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11284,9 +11356,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11357,9 +11437,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11394,9 +11482,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11431,9 +11527,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11468,9 +11572,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11551,9 +11663,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11679,9 +11799,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11716,9 +11844,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11753,9 +11889,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11790,9 +11934,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -11906,9 +12058,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -12009,9 +12169,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -12046,9 +12214,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -12083,9 +12259,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -14332,9 +14516,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -14395,9 +14587,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17560,9 +17760,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17633,9 +17841,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17670,9 +17886,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17707,9 +17931,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17744,9 +17976,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -17781,9 +18021,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -20425,9 +20673,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -20462,9 +20718,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -23323,9 +23587,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -23360,9 +23632,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -24701,9 +24981,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -24738,9 +25026,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -26078,9 +26374,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -26115,9 +26419,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -28197,9 +28509,17 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -29164,9 +29484,17 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -30078,9 +30406,17 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38670,9 +39006,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38707,9 +39051,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38762,9 +39114,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38811,9 +39171,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38860,9 +39228,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38897,9 +39273,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38934,9 +39318,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -38971,9 +39363,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39008,9 +39408,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39045,9 +39453,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39179,9 +39595,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39252,9 +39676,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -39325,9 +39757,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -41566,9 +42006,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -41629,9 +42077,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47234,9 +47690,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47271,9 +47735,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47308,9 +47780,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47345,9 +47825,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47396,9 +47884,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47433,9 +47929,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47470,9 +47974,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47507,9 +48019,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47544,9 +48064,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47581,9 +48109,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47618,9 +48154,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -47655,9 +48199,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -49156,9 +49708,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -49193,9 +49753,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -49230,9 +49798,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58173,9 +58749,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58210,9 +58794,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58265,9 +58857,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58314,9 +58914,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58363,9 +58971,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58400,9 +59016,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58437,9 +59061,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58474,9 +59106,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58511,9 +59151,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58548,9 +59196,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58682,9 +59338,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58755,9 +59419,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -58828,9 +59500,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -60848,9 +61528,17 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -65406,9 +66094,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -65469,9 +66165,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -66219,9 +66923,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -67022,9 +67734,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72775,9 +73495,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72812,9 +73540,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72867,9 +73603,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72916,9 +73660,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -72965,9 +73717,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73002,9 +73762,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73039,9 +73807,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73076,9 +73852,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73113,9 +73897,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73150,9 +73942,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73284,9 +74084,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73357,9 +74165,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -73430,9 +74246,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -79957,9 +80781,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -79994,9 +80826,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80049,9 +80889,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80098,9 +80946,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80147,9 +81003,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80184,9 +81048,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80221,9 +81093,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80258,9 +81138,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80295,9 +81183,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80332,9 +81228,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80466,9 +81370,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80539,9 +81451,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -80612,9 +81532,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -82841,9 +83769,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84527,9 +85463,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84564,9 +85508,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84650,9 +85602,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -84713,9 +85673,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -87096,9 +88064,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -87133,9 +88109,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -87170,9 +88154,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93258,9 +94250,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93295,9 +94295,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93350,9 +94358,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93399,9 +94415,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93448,9 +94472,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93485,9 +94517,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93522,9 +94562,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93559,9 +94607,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93596,9 +94652,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93633,9 +94697,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93767,9 +94839,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93840,9 +94920,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }
@@ -93913,9 +95001,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
+          !URL.canParse(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl))) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
+            : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ||
+          values[\\"@id\\"].startsWith(\\"_:\\") ||
+          !URL.canParse(values[\\"@id\\"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values[\\"@id\\"], options.baseUrl)))
         );
         continue;
       }

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10288,7 +10288,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -10556,7 +10556,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -12960,7 +12960,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -13962,7 +13962,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -16995,7 +16995,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -17838,7 +17838,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18341,7 +18341,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18357,7 +18357,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -18927,7 +18927,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -18943,7 +18943,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -19922,7 +19922,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20371,7 +20371,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20962,7 +20962,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -20978,7 +20978,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21710,7 +21710,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -21726,7 +21726,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -22746,7 +22746,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -23194,7 +23194,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24102,7 +24102,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -24550,7 +24550,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25457,7 +25457,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -25905,7 +25905,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26350,7 +26350,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -26370,7 +26370,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -26703,7 +26703,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27521,7 +27521,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -27537,7 +27537,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28488,7 +28488,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -28504,7 +28504,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -29368,7 +29368,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -29384,7 +29384,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -30203,7 +30203,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -30219,7 +30219,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -31075,7 +31075,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31568,7 +31568,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -31908,7 +31908,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -32243,7 +32243,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -37790,7 +37790,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39253,7 +39253,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -39600,7 +39600,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -40597,7 +40597,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41238,7 +41238,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -41667,7 +41667,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42001,7 +42001,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -42341,7 +42341,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -46164,7 +46164,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48045,7 +48045,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48540,7 +48540,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -48874,7 +48874,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -49206,7 +49206,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50000,7 +50000,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -50016,7 +50016,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -50665,7 +50665,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51000,7 +51000,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -51336,7 +51336,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -56883,7 +56883,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59314,7 +59314,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -59338,7 +59338,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -59997,7 +59997,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60334,7 +60334,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -60669,7 +60669,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61007,7 +61007,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61341,7 +61341,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -61675,7 +61675,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62009,7 +62009,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62341,7 +62341,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62639,7 +62639,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -62974,7 +62974,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -63973,7 +63973,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -64771,7 +64771,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -65559,7 +65559,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -71209,7 +71209,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -72674,7 +72674,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -78221,7 +78221,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -80142,7 +80142,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -81015,7 +81015,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -82678,7 +82678,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83362,7 +83362,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -83696,7 +83696,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85202,7 +85202,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -85707,7 +85707,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -91254,7 +91254,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -92928,7 +92928,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -92944,7 +92944,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string) ? new URL(values[\\"@id\\"] as string) : undefined },
+      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -93360,7 +93360,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -93694,7 +93694,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94244,7 +94244,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -94679,7 +94679,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95018,7 +95018,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95355,7 +95355,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -95692,7 +95692,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   
@@ -96025,7 +96025,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+    if (options.baseUrl == null && values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"])) {
       options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -1,5 +1,5 @@
 exports[`generateClasses() 1`] = `
-"// deno-lint-ignore-file ban-unused-ignore no-unused-vars prefer-const verbatim-module-syntax
+"// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-unused-vars prefer-const verbatim-module-syntax
 import jsonld from \\"@fedify/vocab-runtime/jsonld\\";
 import { getLogger } from \\"@logtape/logtape\\";
 import { type Span, SpanStatusCode, type TracerProvider, trace }
@@ -3661,6 +3661,26 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      
+          {
+            const _ppM0 = await import(\\"./preprocessors.ts\\");
+            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as Image;
+          }
+        
+        }
+      
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -3975,6 +3995,26 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      
+          {
+            const _ppM0 = await import(\\"./preprocessors.ts\\");
+            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as Image;
+          }
+        
+        }
+      
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -10737,6 +10777,29 @@ get urls(): ((URL | Link))[] {
     ) {
       if (v == null) continue;
     
+      {
+        let _handled: Image | undefined;
+      
+        if (_handled === undefined) {
+          const _ppM0 = await import(\\"./preprocessors.ts\\");
+          const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as Image;
+          }
+        }
+      
+        if (_handled !== undefined) {
+          _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(_handled);
+          continue;
+        }
+      }
+      
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
@@ -10770,6 +10833,29 @@ get urls(): ((URL | Link))[] {
     ) {
       if (v == null) continue;
     
+      {
+        let _handled: Image | undefined;
+      
+        if (_handled === undefined) {
+          const _ppM0 = await import(\\"./preprocessors.ts\\");
+          const _result = await _ppM0[\\"normalizeLinkToImage\\"](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as Image;
+          }
+        }
+      
+        if (_handled !== undefined) {
+          _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(_handled);
+          continue;
+        }
+      }
+      
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -3677,23 +3677,25 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === \\"object\\") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       
-          {
-            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as Image;
-          }
+            {
+              const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as Image;
+            }
         
+          }
         }
       
         try {
@@ -4022,23 +4024,25 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === \\"object\\") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       
-          {
-            const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as Image;
-          }
+            {
+              const _result = await _ppM0[\\"normalizeLinkToImage\\"](_pp_obj, {
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as Image;
+            }
         
+          }
         }
       
         try {
@@ -10589,16 +10593,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10635,23 +10639,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10686,7 +10690,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10746,12 +10750,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10835,12 +10839,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10871,7 +10875,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10897,7 +10901,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10926,7 +10930,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
+            baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10952,7 +10956,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10988,12 +10992,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11031,12 +11035,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11074,12 +11078,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11136,7 +11140,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11169,7 +11173,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11202,7 +11206,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11235,7 +11239,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11317,12 +11321,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11381,13 +11385,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11422,7 +11426,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11455,7 +11459,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11488,7 +11492,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11521,7 +11525,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11596,7 +11600,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11629,7 +11633,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11650,7 +11654,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11682,9 +11686,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11716,7 +11720,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11749,7 +11753,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11782,7 +11786,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -14013,7 +14017,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14072,7 +14076,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17184,23 +17188,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17235,7 +17239,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17268,7 +17272,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17301,7 +17305,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17334,7 +17338,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17367,7 +17371,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19973,7 +19977,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20006,7 +20010,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20996,7 +21000,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21017,7 +21021,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21038,7 +21042,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21059,7 +21063,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21755,9 +21759,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21788,9 +21792,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22797,7 +22801,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22830,7 +22834,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24153,7 +24157,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24186,7 +24190,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25508,7 +25512,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25541,7 +25545,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26399,9 +26403,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27585,7 +27589,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28536,23 +28540,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29416,23 +29420,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30266,9 +30270,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30288,7 +30292,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30309,7 +30313,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30330,7 +30334,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31132,7 +31136,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31153,7 +31157,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37865,7 +37869,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37898,7 +37902,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37951,11 +37955,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -37992,11 +37996,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38031,7 +38035,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38064,7 +38068,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38097,7 +38101,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38130,7 +38134,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38163,7 +38167,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38196,7 +38200,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38217,7 +38221,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38324,23 +38328,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38377,23 +38381,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38428,7 +38432,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40648,7 +40652,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40707,7 +40711,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46245,7 +46249,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46278,7 +46282,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46311,7 +46315,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46347,12 +46351,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46387,7 +46391,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46420,7 +46424,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46453,7 +46457,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46486,7 +46490,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46519,7 +46523,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46552,7 +46556,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46585,7 +46589,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46618,7 +46622,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48100,7 +48104,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48133,7 +48137,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48166,7 +48170,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -50045,9 +50049,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50078,9 +50082,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50111,9 +50115,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50144,9 +50148,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50177,9 +50181,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50210,9 +50214,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56958,7 +56962,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56991,7 +56995,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57044,11 +57048,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57085,11 +57089,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57124,7 +57128,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57157,7 +57161,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57190,7 +57194,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57223,7 +57227,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57256,7 +57260,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57289,7 +57293,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57310,7 +57314,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57417,23 +57421,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57470,23 +57474,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57521,7 +57525,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59367,9 +59371,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59518,12 +59522,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -64024,7 +64028,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64083,7 +64087,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64825,12 +64829,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65613,12 +65617,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71284,7 +71288,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71317,7 +71321,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71370,11 +71374,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71411,11 +71415,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71450,7 +71454,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71483,7 +71487,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71516,7 +71520,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71549,7 +71553,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71582,7 +71586,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71615,7 +71619,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71636,7 +71640,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71743,23 +71747,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71796,23 +71800,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71847,7 +71851,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -78296,7 +78300,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78329,7 +78333,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78382,11 +78386,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78423,11 +78427,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78462,7 +78466,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78495,7 +78499,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78528,7 +78532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78561,7 +78565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78594,7 +78598,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78627,7 +78631,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78648,7 +78652,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78755,23 +78759,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78808,23 +78812,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -78859,7 +78863,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80286,9 +80290,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81066,7 +81070,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82729,7 +82733,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82762,7 +82766,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82844,7 +82848,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82903,7 +82907,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -85253,7 +85257,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85286,7 +85290,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85319,7 +85323,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -91329,7 +91333,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91362,7 +91366,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91415,11 +91419,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91456,11 +91460,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91495,7 +91499,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91528,7 +91532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91561,7 +91565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91594,7 +91598,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91627,7 +91631,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91660,7 +91664,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91681,7 +91685,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91788,23 +91792,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91841,23 +91845,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -91892,7 +91896,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+      { ...options, baseUrl: (values[\\"@id\\"] == null || !URL.canParse(values[\\"@id\\"], options.baseUrl) ? options.baseUrl : new URL(values[\\"@id\\"], options.baseUrl)) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10889,6 +10889,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -10936,6 +10937,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -10989,6 +10991,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11046,6 +11049,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11135,6 +11139,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11200,6 +11205,7 @@ get urls(): ((URL | Link))[] {
       
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11255,6 +11261,7 @@ get urls(): ((URL | Link))[] {
       
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11288,6 +11295,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11331,6 +11339,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11374,6 +11383,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11439,6 +11449,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11472,6 +11483,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11505,6 +11517,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11538,6 +11551,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11617,6 +11631,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11725,6 +11740,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11758,6 +11774,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11791,6 +11808,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11824,6 +11842,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -11932,6 +11951,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -12019,6 +12039,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -12052,6 +12073,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -12085,6 +12107,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -14340,6 +14363,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -14399,6 +14423,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17620,6 +17645,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17673,6 +17699,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17706,6 +17733,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17739,6 +17767,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17772,6 +17801,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -17805,6 +17835,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -20455,6 +20486,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -20488,6 +20520,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -23323,6 +23356,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -23356,6 +23390,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -24703,6 +24738,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -24736,6 +24772,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -26082,6 +26119,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -26115,6 +26153,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -28185,6 +28224,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -29153,6 +29193,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -30052,6 +30093,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38681,6 +38723,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38714,6 +38757,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38765,6 +38809,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38806,6 +38851,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38847,6 +38893,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38880,6 +38927,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38913,6 +38961,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38946,6 +38995,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -38979,6 +39029,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39012,6 +39063,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39138,6 +39190,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39191,6 +39244,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -39244,6 +39298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -41491,6 +41546,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -41550,6 +41606,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47211,6 +47268,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47244,6 +47302,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47277,6 +47336,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47310,6 +47370,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47353,6 +47414,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47386,6 +47448,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47419,6 +47482,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47452,6 +47516,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47485,6 +47550,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47518,6 +47584,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47551,6 +47618,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -47584,6 +47652,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -49096,6 +49165,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -49129,6 +49199,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -49162,6 +49233,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58138,6 +58210,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58171,6 +58244,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58222,6 +58296,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58263,6 +58338,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58304,6 +58380,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58337,6 +58414,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58370,6 +58448,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58403,6 +58482,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58436,6 +58516,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58469,6 +58550,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58595,6 +58677,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58648,6 +58731,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -58701,6 +58785,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -60714,6 +60799,7 @@ get names(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -65274,6 +65360,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -65333,6 +65420,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -66084,6 +66172,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -66884,6 +66973,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72714,6 +72804,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72747,6 +72838,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72798,6 +72890,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72839,6 +72932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72880,6 +72974,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72913,6 +73008,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72946,6 +73042,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -72979,6 +73076,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73012,6 +73110,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73045,6 +73144,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73171,6 +73271,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73224,6 +73325,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -73277,6 +73379,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -79885,6 +79988,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -79918,6 +80022,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -79969,6 +80074,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80010,6 +80116,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80051,6 +80158,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80084,6 +80192,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80117,6 +80226,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80150,6 +80260,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80183,6 +80294,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80216,6 +80328,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80342,6 +80455,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80395,6 +80509,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -80448,6 +80563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -82670,6 +82786,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84372,6 +84489,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84405,6 +84523,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84487,6 +84606,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -84546,6 +84666,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -86950,6 +87071,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -86983,6 +87105,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -87016,6 +87139,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93185,6 +93309,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93218,6 +93343,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93269,6 +93395,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93310,6 +93437,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93351,6 +93479,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93384,6 +93513,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93417,6 +93547,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93450,6 +93581,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93483,6 +93615,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93516,6 +93649,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93642,6 +93776,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93695,6 +93830,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
@@ -93748,6 +93884,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v[\\"@id\\"].startsWith(\\"_:\\")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v[\\"@id\\"], options.baseUrl) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -2334,11 +2334,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attachment\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attachment_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#attachment_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -2592,11 +2590,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"attributedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#attribution_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#attribution_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -2692,11 +2688,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"attributedTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#attribution_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#attribution_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -2913,11 +2907,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"audience\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#audience_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#audience_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -3012,11 +3004,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"audience\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#audience_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#audience_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3277,11 +3267,9 @@ get contents(): ((string | LanguageString))[] {
               \\"context\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#context_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#context_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3549,11 +3537,9 @@ get names(): ((string | LanguageString))[] {
               \\"generator\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#generator_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#generator_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3790,11 +3776,13 @@ get names(): ((string | LanguageString))[] {
             \\"icon\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
+      
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      
           }
         }
         
@@ -3890,11 +3878,13 @@ get names(): ((string | LanguageString))[] {
               \\"icon\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
+      
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      
             }
           }
         
@@ -4131,11 +4121,13 @@ get names(): ((string | LanguageString))[] {
             \\"image\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
+      
             v = await this.#image_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      
           }
         }
         
@@ -4231,11 +4223,13 @@ get names(): ((string | LanguageString))[] {
               \\"image\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
+      
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      
             }
           }
         
@@ -4461,11 +4455,9 @@ get names(): ((string | LanguageString))[] {
             \\"inReplyTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replyTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -4560,11 +4552,9 @@ get names(): ((string | LanguageString))[] {
               \\"inReplyTo\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#replyTarget_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#replyTarget_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -4790,11 +4780,9 @@ get names(): ((string | LanguageString))[] {
             \\"location\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#location_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#location_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -4889,11 +4877,9 @@ get names(): ((string | LanguageString))[] {
               \\"location\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#location_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#location_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -5118,11 +5104,9 @@ get names(): ((string | LanguageString))[] {
             \\"preview\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#preview_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#preview_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5216,11 +5200,9 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#preview_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -5450,11 +5432,9 @@ get names(): ((string | LanguageString))[] {
             \\"replies\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replies_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replies_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5676,11 +5656,9 @@ get names(): ((string | LanguageString))[] {
             \\"shares\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#shares_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#shares_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5902,11 +5880,9 @@ get names(): ((string | LanguageString))[] {
             \\"likes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likes_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likes_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6122,11 +6098,9 @@ get names(): ((string | LanguageString))[] {
             \\"emojiReactions\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#emojiReactions_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#emojiReactions_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6394,11 +6368,9 @@ get summaries(): ((string | LanguageString))[] {
               \\"tag\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#tag_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#tag_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -6649,11 +6621,9 @@ get urls(): ((URL | Link))[] {
             \\"to\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#to_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#to_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6748,11 +6718,9 @@ get urls(): ((URL | Link))[] {
               \\"to\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#to_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#to_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -6969,11 +6937,9 @@ get urls(): ((URL | Link))[] {
             \\"bto\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bto_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#bto_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7068,11 +7034,9 @@ get urls(): ((URL | Link))[] {
               \\"bto\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bto_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#bto_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7289,11 +7253,9 @@ get urls(): ((URL | Link))[] {
             \\"cc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#cc_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#cc_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7388,11 +7350,9 @@ get urls(): ((URL | Link))[] {
               \\"cc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#cc_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#cc_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7609,11 +7569,9 @@ get urls(): ((URL | Link))[] {
             \\"bcc\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#bcc_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#bcc_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7708,11 +7666,9 @@ get urls(): ((URL | Link))[] {
               \\"bcc\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#bcc_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#bcc_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7992,11 +7948,9 @@ get urls(): ((URL | Link))[] {
             \\"proof\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#proof_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#proof_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8090,11 +8044,9 @@ get urls(): ((URL | Link))[] {
               \\"proof\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#proof_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#proof_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -8350,11 +8302,9 @@ get urls(): ((URL | Link))[] {
             \\"likeAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likeAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8570,11 +8520,9 @@ get urls(): ((URL | Link))[] {
             \\"replyAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#replyAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8790,11 +8738,9 @@ get urls(): ((URL | Link))[] {
             \\"announceAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#announceAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -10342,14 +10288,9 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -10648,16 +10589,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"http://schema.org#PropertyValue\\") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10694,23 +10635,23 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10745,7 +10686,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10805,12 +10746,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10894,12 +10835,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -10930,7 +10871,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: _baseUrl,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10956,7 +10897,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10985,7 +10926,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: _baseUrl,
+            baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11011,7 +10952,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11047,12 +10988,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11090,12 +11031,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11133,12 +11074,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11195,7 +11136,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11228,7 +11169,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11261,7 +11202,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11294,7 +11235,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11376,12 +11317,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11440,13 +11381,13 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl) : typeof v === \\"object\\" && \\"@type\\" in v
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -11481,7 +11422,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11514,7 +11455,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11547,7 +11488,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11580,7 +11521,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11655,7 +11596,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11688,7 +11629,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11709,7 +11650,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11741,9 +11682,9 @@ get urls(): ((URL | Link))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11775,7 +11716,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11808,7 +11749,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11841,7 +11782,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13019,14 +12960,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -13461,11 +13397,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -13704,11 +13638,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -14030,14 +13962,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -14086,7 +14013,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14145,7 +14072,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -15091,11 +15018,9 @@ instruments?: (Object | URL)[];}
             \\"actor\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#actor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#actor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15191,11 +15116,9 @@ instruments?: (Object | URL)[];}
               \\"actor\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#actor_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#actor_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -15413,11 +15336,9 @@ instruments?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#object_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15513,11 +15434,9 @@ instruments?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#object_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -15738,11 +15657,9 @@ instruments?: (Object | URL)[];}
             \\"target\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#target_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#target_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15841,11 +15758,9 @@ instruments?: (Object | URL)[];}
               \\"target\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#target_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#target_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16063,11 +15978,9 @@ instruments?: (Object | URL)[];}
             \\"result\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#result_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#result_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16163,11 +16076,9 @@ instruments?: (Object | URL)[];}
               \\"result\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#result_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#result_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16386,11 +16297,9 @@ instruments?: (Object | URL)[];}
             \\"origin\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#origin_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#origin_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16487,11 +16396,9 @@ instruments?: (Object | URL)[];}
               \\"origin\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#origin_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#origin_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16708,11 +16615,9 @@ instruments?: (Object | URL)[];}
             \\"instrument\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#instrument_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#instrument_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16807,11 +16712,9 @@ instruments?: (Object | URL)[];}
               \\"instrument\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#instrument_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#instrument_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -17092,14 +16995,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -17286,23 +17184,23 @@ instruments?: (Object | URL)[];}
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -17337,7 +17235,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17370,7 +17268,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17403,7 +17301,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17436,7 +17334,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17469,7 +17367,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17940,14 +17838,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -18448,14 +18341,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -19039,14 +18927,9 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -19543,11 +19426,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -19762,11 +19643,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -20043,14 +19922,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -20099,7 +19973,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20132,7 +20006,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20497,14 +20371,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21093,14 +20962,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21132,7 +20996,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21153,7 +21017,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21174,7 +21038,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21195,7 +21059,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21846,14 +21710,9 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -21896,9 +21755,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21929,9 +21788,9 @@ get manualApprovals(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22391,11 +22250,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -22610,11 +22467,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -22891,14 +22746,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -22947,7 +22797,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22980,7 +22830,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23344,14 +23194,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -23761,11 +23606,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -23980,11 +23823,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -24261,14 +24102,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -24317,7 +24153,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24350,7 +24186,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24714,14 +24550,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25130,11 +24961,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactingObject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -25349,11 +25178,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"interactionTarget\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -25630,14 +25457,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -25686,7 +25508,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25719,7 +25541,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26083,14 +25905,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26533,14 +26350,9 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -26587,9 +26399,9 @@ get endpoints(): (URL)[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26891,14 +26703,9 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27714,14 +27521,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -27783,7 +27585,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28409,11 +28211,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
             \\"owner\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#owner_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#owner_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -28688,14 +28488,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -28741,23 +28536,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -29289,11 +29084,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
             \\"controller\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#controller_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#controller_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -29575,14 +29368,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -29628,23 +29416,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -30415,14 +30203,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -30483,9 +30266,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30505,7 +30288,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30526,7 +30309,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30547,7 +30330,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31292,14 +31075,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -31354,7 +31132,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31375,7 +31153,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31790,14 +31568,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32135,14 +31908,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -32475,14 +32243,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -33756,11 +33519,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -33853,11 +33614,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -34076,11 +33835,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34177,11 +33934,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -34437,11 +34192,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34674,11 +34427,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34897,11 +34648,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35123,11 +34872,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35347,11 +35094,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35569,11 +35314,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35791,11 +35534,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36011,11 +35752,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -36341,11 +36080,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36599,11 +36336,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36700,11 +36435,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -36923,11 +36656,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -37024,11 +36755,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -38061,14 +37790,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -38141,7 +37865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38174,7 +37898,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38227,11 +37951,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38268,11 +37992,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38307,7 +38031,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38340,7 +38064,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38373,7 +38097,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38406,7 +38130,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38439,7 +38163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38472,7 +38196,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38493,7 +38217,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38600,23 +38324,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38653,23 +38377,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -38704,7 +38428,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39529,14 +39253,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -39881,14 +39600,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40318,11 +40032,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -40561,11 +40273,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -40887,14 +40597,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -40943,7 +40648,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -41002,7 +40707,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41533,14 +41238,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -41967,14 +41667,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42306,14 +42001,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -42651,14 +42341,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -43411,11 +43096,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"current\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#current_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#current_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -43631,11 +43314,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"first\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#first_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#first_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -43851,11 +43532,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"last\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#last_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#last_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44081,11 +43760,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"items\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -44301,11 +43978,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44520,11 +44195,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"sharesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#sharesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#sharesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44739,11 +44412,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"repliesOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#repliesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#repliesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44958,11 +44629,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"inboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inboxOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inboxOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45177,11 +44846,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"outboxOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outboxOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outboxOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45396,11 +45063,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followersOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followersOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followersOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45615,11 +45280,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"followingOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followingOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followingOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45834,11 +45497,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"likedOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#likedOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likedOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -46503,14 +46164,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -46589,7 +46245,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46622,7 +46278,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46655,7 +46311,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46691,12 +46347,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -46731,7 +46387,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46764,7 +46420,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46797,7 +46453,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46830,7 +46486,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46863,7 +46519,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46896,7 +46552,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46929,7 +46585,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46962,7 +46618,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47642,11 +47298,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"partOf\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#partOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#partOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -47860,11 +47514,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"next\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#next_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#next_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -48079,11 +47731,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"prev\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#prev_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#prev_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -48395,14 +48045,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -48455,7 +48100,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48488,7 +48133,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48521,7 +48166,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48895,14 +48540,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49234,14 +48874,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -49571,14 +49206,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50370,14 +50000,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -50420,9 +50045,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50453,9 +50078,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50486,9 +50111,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50519,9 +50144,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50552,9 +50177,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50585,9 +50210,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -51040,14 +50665,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51380,14 +51000,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -51721,14 +51336,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -53002,11 +52612,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53099,11 +52707,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -53322,11 +52928,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53423,11 +53027,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -53683,11 +53285,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53920,11 +53520,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54143,11 +53741,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54369,11 +53965,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54593,11 +54187,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54815,11 +54407,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55037,11 +54627,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55257,11 +54845,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -55587,11 +55173,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55845,11 +55429,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55946,11 +55528,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -56169,11 +55749,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -56270,11 +55848,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -57307,14 +56883,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -57387,7 +56958,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57420,7 +56991,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57473,11 +57044,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57514,11 +57085,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57553,7 +57124,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57586,7 +57157,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57619,7 +57190,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57652,7 +57223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57685,7 +57256,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57718,7 +57289,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57739,7 +57310,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57846,23 +57417,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57899,23 +57470,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -57950,7 +57521,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59287,11 +58858,9 @@ get names(): ((string | LanguageString))[] {
               \\"preview\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#preview_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#preview_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -59745,14 +59314,9 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -59803,9 +59367,9 @@ get names(): ((string | LanguageString))[] {
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl);
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])));
       if (typeof decoded === \\"undefined\\") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59954,12 +59518,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -60433,14 +59997,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -60775,14 +60334,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61115,14 +60669,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61458,14 +61007,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -61797,14 +61341,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62136,14 +61675,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62475,14 +62009,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -62812,14 +62341,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63115,14 +62639,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63455,14 +62974,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -63894,11 +63408,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -64137,11 +63649,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -64463,14 +63973,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -64519,7 +64024,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64578,7 +64083,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -65020,11 +64525,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -65268,14 +64771,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -65327,12 +64825,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -65766,11 +65264,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               \\"orderedItems\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -66063,14 +65559,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -66122,12 +65613,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://gotosocial.org/ns#AnnounceAuthorization\\",\\"https://gotosocial.org/ns#LikeApproval\\",\\"https://gotosocial.org/ns#ReplyAuthorization\\",\\"https://w3id.org/fep/044f#QuoteAuthorization\\",\\"https://w3id.org/valueflows/ont/vf#Proposal\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://gotosocial.org/ns#AnnounceRequest\\",\\"https://gotosocial.org/ns#LikeRequest\\",\\"https://gotosocial.org/ns#ReplyRequest\\",\\"https://w3id.org/fep/044f#QuoteRequest\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -67447,11 +66938,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -67544,11 +67033,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -67767,11 +67254,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -67868,11 +67353,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -68128,11 +67611,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68365,11 +67846,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68588,11 +68067,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68814,11 +68291,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69038,11 +68513,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69260,11 +68733,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69482,11 +68953,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69702,11 +69171,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -70032,11 +69499,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70290,11 +69755,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70391,11 +69854,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -70614,11 +70075,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70715,11 +70174,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -71752,14 +71209,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -71832,7 +71284,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71865,7 +71317,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71918,11 +71370,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71959,11 +71411,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -71998,7 +71450,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -72031,7 +71483,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -72064,7 +71516,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -72097,7 +71549,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -72130,7 +71582,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -72163,7 +71615,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -72184,7 +71636,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -72291,23 +71743,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72344,23 +71796,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -72395,7 +71847,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -73222,14 +72674,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -74503,11 +73950,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -74600,11 +74045,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -74823,11 +74266,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -74924,11 +74365,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -75184,11 +74623,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75421,11 +74858,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75644,11 +75079,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75870,11 +75303,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76094,11 +75525,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76316,11 +75745,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76538,11 +75965,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76758,11 +76183,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -77088,11 +76511,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77346,11 +76767,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77447,11 +76866,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -77670,11 +77087,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77771,11 +77186,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -78808,14 +78221,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -78888,7 +78296,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78921,7 +78329,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78974,11 +78382,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79015,11 +78423,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79054,7 +78462,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -79087,7 +78495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -79120,7 +78528,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -79153,7 +78561,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -79186,7 +78594,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -79219,7 +78627,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -79240,7 +78648,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79347,23 +78755,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79400,23 +78808,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -79451,7 +78859,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80734,14 +80142,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -80883,9 +80286,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : \\"\\"
           )
         )
-        : URL.canParse(v[\\"@id\\"]) && _baseUrl
+        : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], _baseUrl) : undefined
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81368,11 +80771,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             \\"describes\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#describes_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#describes_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -81614,14 +81015,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -81670,7 +81066,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82263,11 +81659,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"oneOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#exclusiveOption_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -82486,11 +81880,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               \\"anyOf\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#inclusiveOption_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -82738,11 +82130,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quote\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -82981,11 +82371,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             \\"quoteAuthorization\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -83290,14 +82678,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -83346,7 +82729,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83379,7 +82762,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83461,7 +82844,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83520,7 +82903,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83979,14 +83362,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -84318,14 +83696,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -84883,11 +84256,9 @@ relationships?: (Object | URL)[];}
             \\"subject\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#subject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#subject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85102,11 +84473,9 @@ relationships?: (Object | URL)[];}
             \\"object\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#object_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#object_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85200,11 +84569,9 @@ relationships?: (Object | URL)[];}
               \\"object\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#object_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#object_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -85422,11 +84789,9 @@ relationships?: (Object | URL)[];}
             \\"relationship\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#relationship_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#relationship_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85522,11 +84887,9 @@ relationships?: (Object | URL)[];}
               \\"relationship\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#relationship_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#relationship_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -85839,14 +85202,9 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -85895,7 +85253,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85928,7 +85286,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85961,7 +85319,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86349,14 +85707,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -87630,11 +86983,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"publicKey\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -87727,11 +87078,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"publicKey\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -87950,11 +87299,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"assertionMethod\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88051,11 +87398,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"assertionMethod\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -88311,11 +87656,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"inbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88548,11 +87891,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"outbox\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88771,11 +88112,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"following\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88997,11 +88336,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"followers\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89221,11 +88558,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"liked\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89443,11 +88778,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featured\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89665,11 +88998,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"featuredTags\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89885,11 +89216,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"streams\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -90215,11 +89544,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"movedTo\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90473,11 +89800,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"alsoKnownAs\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90574,11 +89899,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"alsoKnownAs\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -90797,11 +90120,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             \\"service\\"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === \\"object\\" && \\"@context\\" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90898,11 +90219,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               \\"service\\"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === \\"object\\" && \\"@context\\" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -91935,14 +91254,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -92015,7 +91329,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -92048,7 +91362,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -92101,11 +91415,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92142,11 +91456,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92181,7 +91495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -92214,7 +91528,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -92247,7 +91561,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -92280,7 +91594,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -92313,7 +91627,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -92346,7 +91660,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92367,7 +91681,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92474,23 +91788,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92527,23 +91841,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Group\\") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Organization\\") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Person\\") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Service\\") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
@@ -92578,7 +91892,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     );
       if (typeof decoded === \\"undefined\\") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93614,14 +92928,9 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94051,14 +93360,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94390,14 +93694,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -94945,14 +94244,9 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95385,14 +94679,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -95729,14 +95018,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96071,14 +95355,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96413,14 +95692,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);
@@ -96751,14 +96025,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { \\"@id\\"?: string });
     }
-    const _resolvedUrl =
-      values[\\"@id\\"] != null && URL.canParse(values[\\"@id\\"], options.baseUrl)
-        ? new URL(values[\\"@id\\"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values[\\"@id\\"] != null) {
+      options = { ...options, baseUrl: new URL(values[\\"@id\\"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if (\\"@type\\" in values) {
     span.setAttribute(\\"activitypub.object.type\\", values[\\"@type\\"]);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -10567,7 +10567,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -18599,7 +18599,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19192,7 +19192,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -21242,7 +21242,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -22013,7 +22013,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -26704,7 +26704,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -27886,7 +27886,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
@@ -28864,7 +28864,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -29771,7 +29771,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -30633,7 +30633,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -50633,7 +50633,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -60106,7 +60106,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -94087,7 +94087,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: \\"@id\\" in values && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
+      { id: \\"@id\\" in values && !(values[\\"@id\\"] as string).startsWith(\\"_:\\") && URL.canParse(values[\\"@id\\"] as string, options.baseUrl) ? new URL(values[\\"@id\\"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10425,7 +10425,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -13273,7 +13273,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -14283,7 +14283,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -17372,7 +17372,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -18255,7 +18255,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -18765,7 +18765,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -19358,7 +19358,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -20361,7 +20361,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -20818,7 +20818,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -21416,7 +21416,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -22187,7 +22187,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -23247,7 +23247,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -23703,7 +23703,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -24619,7 +24619,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -25075,7 +25075,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -25990,7 +25990,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -26446,7 +26446,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -26898,7 +26898,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -27259,7 +27259,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -28084,7 +28084,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -29066,7 +29066,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -29977,7 +29977,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -30839,7 +30839,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -31731,7 +31731,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -32232,7 +32232,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -32572,7 +32572,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -32907,7 +32907,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -38522,7 +38522,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -40081,7 +40081,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -40428,7 +40428,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -41433,7 +41433,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -42082,7 +42082,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -42511,7 +42511,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -42845,7 +42845,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -43185,7 +43185,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -47056,7 +47056,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -49001,7 +49001,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -49508,7 +49508,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -49842,7 +49842,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -50174,7 +50174,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -50975,7 +50975,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -51688,7 +51688,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -52023,7 +52023,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -52359,7 +52359,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -57974,7 +57974,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -60512,7 +60512,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -61211,7 +61211,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -61548,7 +61548,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -61883,7 +61883,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -62221,7 +62221,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -62555,7 +62555,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -62889,7 +62889,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -63223,7 +63223,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -63555,7 +63555,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -63853,7 +63853,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -64188,7 +64188,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -65195,7 +65195,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -66005,7 +66005,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -66805,7 +66805,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -72531,7 +72531,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -74092,7 +74092,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -79707,7 +79707,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -81724,7 +81724,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -82609,7 +82609,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -84292,7 +84292,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -84992,7 +84992,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -85326,7 +85326,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -86852,7 +86852,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -87369,7 +87369,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -92984,7 +92984,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -94761,7 +94761,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -95193,7 +95193,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -95527,7 +95527,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -96077,7 +96077,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -96512,7 +96512,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -96851,7 +96851,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -97188,7 +97188,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -97525,7 +97525,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
@@ -97858,7 +97858,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -2336,11 +2336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "attachment"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#attachment_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#attachment_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -2594,11 +2592,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "attributedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#attribution_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#attribution_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -2694,11 +2690,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "attributedTo"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#attribution_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#attribution_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -2915,11 +2909,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "audience"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#audience_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#audience_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -3014,11 +3006,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "audience"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#audience_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#audience_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3279,11 +3269,9 @@ get contents(): ((string | LanguageString))[] {
               "context"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#context_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#context_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3551,11 +3539,9 @@ get names(): ((string | LanguageString))[] {
               "generator"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#generator_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#generator_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -3792,11 +3778,13 @@ get names(): ((string | LanguageString))[] {
             "icon"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
+      
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      
           }
         }
         
@@ -3892,11 +3880,13 @@ get names(): ((string | LanguageString))[] {
               "icon"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
+      
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      
             }
           }
         
@@ -4133,11 +4123,13 @@ get names(): ((string | LanguageString))[] {
             "image"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
+      
             v = await this.#image_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      
           }
         }
         
@@ -4233,11 +4225,13 @@ get names(): ((string | LanguageString))[] {
               "image"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
+      
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      
             }
           }
         
@@ -4463,11 +4457,9 @@ get names(): ((string | LanguageString))[] {
             "inReplyTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#replyTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replyTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -4562,11 +4554,9 @@ get names(): ((string | LanguageString))[] {
               "inReplyTo"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#replyTarget_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#replyTarget_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -4792,11 +4782,9 @@ get names(): ((string | LanguageString))[] {
             "location"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#location_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#location_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -4891,11 +4879,9 @@ get names(): ((string | LanguageString))[] {
               "location"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#location_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#location_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -5120,11 +5106,9 @@ get names(): ((string | LanguageString))[] {
             "preview"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#preview_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#preview_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5218,11 +5202,9 @@ get names(): ((string | LanguageString))[] {
               "preview"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#preview_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#preview_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -5452,11 +5434,9 @@ get names(): ((string | LanguageString))[] {
             "replies"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#replies_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replies_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5678,11 +5658,9 @@ get names(): ((string | LanguageString))[] {
             "shares"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#shares_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#shares_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -5904,11 +5882,9 @@ get names(): ((string | LanguageString))[] {
             "likes"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likes_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likes_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6124,11 +6100,9 @@ get names(): ((string | LanguageString))[] {
             "emojiReactions"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#emojiReactions_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#emojiReactions_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6396,11 +6370,9 @@ get summaries(): ((string | LanguageString))[] {
               "tag"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#tag_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#tag_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -6651,11 +6623,9 @@ get urls(): ((URL | Link))[] {
             "to"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#to_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#to_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -6750,11 +6720,9 @@ get urls(): ((URL | Link))[] {
               "to"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#to_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#to_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -6971,11 +6939,9 @@ get urls(): ((URL | Link))[] {
             "bto"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#bto_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#bto_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7070,11 +7036,9 @@ get urls(): ((URL | Link))[] {
               "bto"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#bto_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#bto_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7291,11 +7255,9 @@ get urls(): ((URL | Link))[] {
             "cc"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#cc_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#cc_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7390,11 +7352,9 @@ get urls(): ((URL | Link))[] {
               "cc"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#cc_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#cc_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7611,11 +7571,9 @@ get urls(): ((URL | Link))[] {
             "bcc"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#bcc_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#bcc_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -7710,11 +7668,9 @@ get urls(): ((URL | Link))[] {
               "bcc"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#bcc_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#bcc_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -7994,11 +7950,9 @@ get urls(): ((URL | Link))[] {
             "proof"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#proof_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#proof_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8092,11 +8046,9 @@ get urls(): ((URL | Link))[] {
               "proof"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#proof_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#proof_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -8352,11 +8304,9 @@ get urls(): ((URL | Link))[] {
             "likeAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likeAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8572,11 +8522,9 @@ get urls(): ((URL | Link))[] {
             "replyAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#replyAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -8792,11 +8740,9 @@ get urls(): ((URL | Link))[] {
             "announceAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#announceAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -10344,14 +10290,9 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -10650,16 +10591,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10696,23 +10637,23 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10747,7 +10688,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10807,12 +10748,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10896,12 +10837,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10932,7 +10873,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: _baseUrl,
+            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10958,7 +10899,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10987,7 +10928,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: _baseUrl,
+            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11013,7 +10954,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11049,12 +10990,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11092,12 +11033,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11135,12 +11076,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11197,7 +11138,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11230,7 +11171,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11263,7 +11204,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11296,7 +11237,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11378,12 +11319,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11442,13 +11383,13 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11483,7 +11424,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11516,7 +11457,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11549,7 +11490,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11582,7 +11523,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11657,7 +11598,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11690,7 +11631,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11711,7 +11652,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11743,9 +11684,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11777,7 +11718,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11810,7 +11751,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11843,7 +11784,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13021,14 +12962,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -13463,11 +13399,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -13706,11 +13640,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -14032,14 +13964,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -14088,7 +14015,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14147,7 +14074,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -15093,11 +15020,9 @@ instruments?: (Object | URL)[];}
             "actor"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#actor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#actor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15193,11 +15118,9 @@ instruments?: (Object | URL)[];}
               "actor"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#actor_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#actor_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -15415,11 +15338,9 @@ instruments?: (Object | URL)[];}
             "object"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#object_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#object_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15515,11 +15436,9 @@ instruments?: (Object | URL)[];}
               "object"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#object_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#object_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -15740,11 +15659,9 @@ instruments?: (Object | URL)[];}
             "target"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#target_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#target_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -15843,11 +15760,9 @@ instruments?: (Object | URL)[];}
               "target"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#target_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#target_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16065,11 +15980,9 @@ instruments?: (Object | URL)[];}
             "result"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#result_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#result_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16165,11 +16078,9 @@ instruments?: (Object | URL)[];}
               "result"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#result_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#result_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16388,11 +16299,9 @@ instruments?: (Object | URL)[];}
             "origin"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#origin_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#origin_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16489,11 +16398,9 @@ instruments?: (Object | URL)[];}
               "origin"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#origin_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#origin_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -16710,11 +16617,9 @@ instruments?: (Object | URL)[];}
             "instrument"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#instrument_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#instrument_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -16809,11 +16714,9 @@ instruments?: (Object | URL)[];}
               "instrument"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#instrument_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#instrument_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -17094,14 +16997,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -17288,23 +17186,23 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17339,7 +17237,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17372,7 +17270,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17405,7 +17303,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17438,7 +17336,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17471,7 +17369,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17942,14 +17840,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -18450,14 +18343,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -19041,14 +18929,9 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -19545,11 +19428,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -19764,11 +19645,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -20045,14 +19924,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -20101,7 +19975,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20134,7 +20008,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20499,14 +20373,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -21095,14 +20964,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -21134,7 +20998,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21155,7 +21019,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21176,7 +21040,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21197,7 +21061,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21848,14 +21712,9 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -21898,9 +21757,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21931,9 +21790,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22393,11 +22252,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -22612,11 +22469,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -22893,14 +22748,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -22949,7 +22799,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22982,7 +22832,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23346,14 +23196,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -23763,11 +23608,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -23982,11 +23825,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -24263,14 +24104,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -24319,7 +24155,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24352,7 +24188,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24716,14 +24552,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -25132,11 +24963,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactingObject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -25351,11 +25180,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#interactionTarget_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -25632,14 +25459,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -25688,7 +25510,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25721,7 +25543,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26085,14 +25907,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -26535,14 +26352,9 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -26589,9 +26401,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26893,14 +26705,9 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -27716,14 +27523,9 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -27785,7 +27587,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28411,11 +28213,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
             "owner"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#owner_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#owner_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -28690,14 +28490,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -28743,23 +28538,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -29291,11 +29086,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
             "controller"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#controller_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#controller_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -29577,14 +29370,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -29630,23 +29418,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30417,14 +30205,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -30485,9 +30268,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30507,7 +30290,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30528,7 +30311,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30549,7 +30332,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31294,14 +31077,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -31356,7 +31134,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31377,7 +31155,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31792,14 +31570,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -32137,14 +31910,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -32477,14 +32245,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -33758,11 +33521,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -33855,11 +33616,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -34078,11 +33837,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34179,11 +33936,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -34439,11 +34194,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34676,11 +34429,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -34899,11 +34650,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35125,11 +34874,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35349,11 +35096,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35571,11 +35316,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -35793,11 +35536,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36013,11 +35754,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -36343,11 +36082,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36601,11 +36338,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -36702,11 +36437,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -36925,11 +36658,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -37026,11 +36757,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -38063,14 +37792,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -38143,7 +37867,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38176,7 +37900,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38229,11 +37953,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38270,11 +37994,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38309,7 +38033,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38342,7 +38066,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38375,7 +38099,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38408,7 +38132,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38441,7 +38165,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38474,7 +38198,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38495,7 +38219,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38602,23 +38326,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38655,23 +38379,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38706,7 +38430,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39531,14 +39255,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -39883,14 +39602,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -40320,11 +40034,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -40563,11 +40275,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -40889,14 +40599,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -40945,7 +40650,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -41004,7 +40709,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41535,14 +41240,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -41969,14 +41669,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -42308,14 +42003,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -42653,14 +42343,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -43413,11 +43098,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "current"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#current_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#current_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -43633,11 +43316,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "first"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#first_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#first_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -43853,11 +43534,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "last"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#last_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#last_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44083,11 +43762,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "items"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -44303,11 +43980,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "likesOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44522,11 +44197,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "sharesOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#sharesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#sharesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44741,11 +44414,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "repliesOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#repliesOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#repliesOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -44960,11 +44631,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "inboxOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inboxOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inboxOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45179,11 +44848,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "outboxOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outboxOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outboxOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45398,11 +45065,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "followersOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followersOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followersOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45617,11 +45282,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "followingOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followingOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followingOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -45836,11 +45499,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "likedOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likedOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#likedOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -46505,14 +46166,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -46591,7 +46247,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46624,7 +46280,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46657,7 +46313,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46693,12 +46349,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -46733,7 +46389,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46766,7 +46422,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46799,7 +46455,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46832,7 +46488,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46865,7 +46521,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46898,7 +46554,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46931,7 +46587,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46964,7 +46620,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47644,11 +47300,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "partOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#partOf_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#partOf_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -47862,11 +47516,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "next"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#next_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#next_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -48081,11 +47733,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "prev"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#prev_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#prev_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -48397,14 +48047,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -48457,7 +48102,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48490,7 +48135,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48523,7 +48168,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48897,14 +48542,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -49236,14 +48876,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -49573,14 +49208,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -50372,14 +50002,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -50422,9 +50047,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50455,9 +50080,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50488,9 +50113,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50521,9 +50146,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50554,9 +50179,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50587,9 +50212,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -51042,14 +50667,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -51382,14 +51002,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -51723,14 +51338,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -53004,11 +52614,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53101,11 +52709,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -53324,11 +52930,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53425,11 +53029,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -53685,11 +53287,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -53922,11 +53522,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54145,11 +53743,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54371,11 +53967,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54595,11 +54189,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -54817,11 +54409,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55039,11 +54629,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55259,11 +54847,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -55589,11 +55175,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55847,11 +55431,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -55948,11 +55530,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -56171,11 +55751,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -56272,11 +55850,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -57309,14 +56885,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -57389,7 +56960,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57422,7 +56993,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57475,11 +57046,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57516,11 +57087,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57555,7 +57126,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57588,7 +57159,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57621,7 +57192,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57654,7 +57225,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57687,7 +57258,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57720,7 +57291,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57741,7 +57312,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57848,23 +57419,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57901,23 +57472,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57952,7 +57523,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59289,11 +58860,9 @@ get names(): ((string | LanguageString))[] {
               "preview"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#preview_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#preview_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -59747,14 +59316,9 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -59805,9 +59369,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl);
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59956,12 +59520,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -60435,14 +59999,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -60777,14 +60336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -61117,14 +60671,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -61460,14 +61009,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -61799,14 +61343,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -62138,14 +61677,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -62477,14 +62011,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -62814,14 +62343,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -63117,14 +62641,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -63457,14 +62976,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -63896,11 +63410,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -64139,11 +63651,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -64465,14 +63975,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -64521,7 +64026,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64580,7 +64085,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -65022,11 +64527,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "orderedItems"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -65270,14 +64773,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -65329,12 +64827,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65768,11 +65266,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "orderedItems"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#item_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#item_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -66065,14 +65561,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -66124,12 +65615,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -67449,11 +66940,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -67546,11 +67035,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -67769,11 +67256,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -67870,11 +67355,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -68130,11 +67613,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68367,11 +67848,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68590,11 +68069,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -68816,11 +68293,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69040,11 +68515,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69262,11 +68735,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69484,11 +68955,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -69704,11 +69173,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -70034,11 +69501,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70292,11 +69757,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70393,11 +69856,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -70616,11 +70077,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -70717,11 +70176,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -71754,14 +71211,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -71834,7 +71286,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71867,7 +71319,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71920,11 +71372,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71961,11 +71413,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72000,7 +71452,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -72033,7 +71485,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -72066,7 +71518,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -72099,7 +71551,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -72132,7 +71584,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -72165,7 +71617,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -72186,7 +71638,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -72293,23 +71745,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72346,23 +71798,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72397,7 +71849,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -73224,14 +72676,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -74505,11 +73952,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -74602,11 +74047,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -74825,11 +74268,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -74926,11 +74367,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -75186,11 +74625,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75423,11 +74860,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75646,11 +75081,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -75872,11 +75305,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76096,11 +75527,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76318,11 +75747,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76540,11 +75967,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -76760,11 +76185,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -77090,11 +76513,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77348,11 +76769,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77449,11 +76868,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -77672,11 +77089,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -77773,11 +77188,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -78810,14 +78223,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -78890,7 +78298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78923,7 +78331,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78976,11 +78384,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79017,11 +78425,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79056,7 +78464,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -79089,7 +78497,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -79122,7 +78530,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -79155,7 +78563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -79188,7 +78596,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -79221,7 +78629,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -79242,7 +78650,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79349,23 +78757,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79402,23 +78810,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79453,7 +78861,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80736,14 +80144,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -80885,9 +80288,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && _baseUrl
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], _baseUrl) : undefined
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81370,11 +80773,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "describes"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#describes_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#describes_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -81616,14 +81017,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -81672,7 +81068,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82265,11 +81661,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               "oneOf"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#exclusiveOption_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -82488,11 +81882,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               "anyOf"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#inclusiveOption_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -82740,11 +82132,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quote_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -82983,11 +82373,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -83292,14 +82680,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -83348,7 +82731,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83381,7 +82764,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83463,7 +82846,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83522,7 +82905,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83981,14 +83364,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -84320,14 +83698,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -84885,11 +84258,9 @@ relationships?: (Object | URL)[];}
             "subject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#subject_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#subject_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85104,11 +84475,9 @@ relationships?: (Object | URL)[];}
             "object"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#object_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#object_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85202,11 +84571,9 @@ relationships?: (Object | URL)[];}
               "object"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#object_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#object_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -85424,11 +84791,9 @@ relationships?: (Object | URL)[];}
             "relationship"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#relationship_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#relationship_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -85524,11 +84889,9 @@ relationships?: (Object | URL)[];}
               "relationship"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#relationship_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#relationship_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -85841,14 +85204,9 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -85897,7 +85255,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85930,7 +85288,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85963,7 +85321,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86351,14 +85709,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -87632,11 +86985,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#publicKey_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -87729,11 +87080,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#publicKey_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -87952,11 +87301,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#assertionMethod_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88053,11 +87400,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#assertionMethod_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -88313,11 +87658,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#inbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88550,11 +87893,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#outbox_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88773,11 +88114,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#following_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -88999,11 +88338,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#followers_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89223,11 +88560,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#liked_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89445,11 +88780,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featured_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89667,11 +89000,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#featuredTags_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -89887,11 +89218,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#stream_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -90217,11 +89546,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#successor_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90475,11 +89802,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#alias_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90576,11 +89901,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#alias_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -90799,11 +90122,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
-            });
+      
+            v = await this.#service_fromJsonLd(doc, options);
+      
           }
         }
         
@@ -90900,11 +90221,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
-              });
+      
+              v = await this.#service_fromJsonLd(obj, options);
+      
             }
           }
         
@@ -91937,14 +91256,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -92017,7 +91331,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -92050,7 +91364,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -92103,11 +91417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -92144,11 +91458,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -92183,7 +91497,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -92216,7 +91530,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -92249,7 +91563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -92282,7 +91596,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -92315,7 +91629,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -92348,7 +91662,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92369,7 +91683,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92476,23 +91790,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -92529,23 +91843,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -92580,7 +91894,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: _baseUrl }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93616,14 +92930,9 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -94053,14 +93362,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -94392,14 +93696,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -94947,14 +94246,9 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -95387,14 +94681,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -95731,14 +95020,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -96073,14 +95357,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -96415,14 +95694,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -96753,14 +96027,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -2344,7 +2344,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#attachment_fromJsonLd(obj, options);
+              v = await this.#attachment_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -2600,7 +2604,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#attribution_fromJsonLd(doc, options);
+            v = await this.#attribution_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -2698,7 +2706,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#attribution_fromJsonLd(obj, options);
+              v = await this.#attribution_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -2917,7 +2929,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#audience_fromJsonLd(doc, options);
+            v = await this.#audience_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -3014,7 +3030,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#audience_fromJsonLd(obj, options);
+              v = await this.#audience_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -3277,7 +3297,11 @@ get contents(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#context_fromJsonLd(obj, options);
+              v = await this.#context_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -3547,7 +3571,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#generator_fromJsonLd(obj, options);
+              v = await this.#generator_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -4469,7 +4497,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#replyTarget_fromJsonLd(doc, options);
+            v = await this.#replyTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -4566,7 +4598,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#replyTarget_fromJsonLd(obj, options);
+              v = await this.#replyTarget_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -4794,7 +4830,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#location_fromJsonLd(doc, options);
+            v = await this.#location_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -4891,7 +4931,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#location_fromJsonLd(obj, options);
+              v = await this.#location_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -5118,7 +5162,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#preview_fromJsonLd(doc, options);
+            v = await this.#preview_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5214,7 +5262,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -5446,7 +5498,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#replies_fromJsonLd(doc, options);
+            v = await this.#replies_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5670,7 +5726,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#shares_fromJsonLd(doc, options);
+            v = await this.#shares_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -5894,7 +5954,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#likes_fromJsonLd(doc, options);
+            v = await this.#likes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6112,7 +6176,11 @@ get names(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#emojiReactions_fromJsonLd(doc, options);
+            v = await this.#emojiReactions_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6382,7 +6450,11 @@ get summaries(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#tag_fromJsonLd(obj, options);
+              v = await this.#tag_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -6635,7 +6707,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#to_fromJsonLd(doc, options);
+            v = await this.#to_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -6732,7 +6808,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#to_fromJsonLd(obj, options);
+              v = await this.#to_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -6951,7 +7031,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#bto_fromJsonLd(doc, options);
+            v = await this.#bto_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7048,7 +7132,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#bto_fromJsonLd(obj, options);
+              v = await this.#bto_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7267,7 +7355,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#cc_fromJsonLd(doc, options);
+            v = await this.#cc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7364,7 +7456,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#cc_fromJsonLd(obj, options);
+              v = await this.#cc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7583,7 +7679,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#bcc_fromJsonLd(doc, options);
+            v = await this.#bcc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -7680,7 +7780,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#bcc_fromJsonLd(obj, options);
+              v = await this.#bcc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -7962,7 +8066,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#proof_fromJsonLd(doc, options);
+            v = await this.#proof_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8058,7 +8166,11 @@ get urls(): ((URL | Link))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#proof_fromJsonLd(obj, options);
+              v = await this.#proof_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -8316,7 +8428,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+            v = await this.#likeAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8534,7 +8650,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+            v = await this.#replyAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -8752,7 +8872,11 @@ get urls(): ((URL | Link))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+            v = await this.#announceAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -10301,8 +10425,8 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -13149,8 +13273,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -13587,7 +13711,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -13828,7 +13956,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -14151,8 +14283,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -15216,7 +15348,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#actor_fromJsonLd(doc, options);
+            v = await this.#actor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15314,7 +15450,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#actor_fromJsonLd(obj, options);
+              v = await this.#actor_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -15534,7 +15674,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15632,7 +15776,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -15855,7 +16003,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#target_fromJsonLd(doc, options);
+            v = await this.#target_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -15956,7 +16108,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#target_fromJsonLd(obj, options);
+              v = await this.#target_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16176,7 +16332,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#result_fromJsonLd(doc, options);
+            v = await this.#result_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16274,7 +16434,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#result_fromJsonLd(obj, options);
+              v = await this.#result_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16495,7 +16659,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#origin_fromJsonLd(doc, options);
+            v = await this.#origin_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16594,7 +16762,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#origin_fromJsonLd(obj, options);
+              v = await this.#origin_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -16813,7 +16985,11 @@ instruments?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#instrument_fromJsonLd(doc, options);
+            v = await this.#instrument_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -16910,7 +17086,11 @@ instruments?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#instrument_fromJsonLd(obj, options);
+              v = await this.#instrument_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -17192,8 +17372,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -18075,8 +18255,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -18585,8 +18765,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -19178,8 +19358,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -19678,7 +19858,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -19895,7 +20079,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -20173,8 +20361,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -20630,8 +20818,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -21228,8 +21416,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -21999,8 +22187,8 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -22556,7 +22744,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -22773,7 +22965,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -23051,8 +23247,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -23507,8 +23703,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -23920,7 +24116,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -24137,7 +24337,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -24415,8 +24619,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -24871,8 +25075,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -25283,7 +25487,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -25500,7 +25708,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -25778,8 +25990,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -26234,8 +26446,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -26686,8 +26898,8 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -27047,8 +27259,8 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -27872,8 +28084,8 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -28574,7 +28786,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#owner_fromJsonLd(doc, options);
+            v = await this.#owner_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -28850,8 +29066,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -29474,7 +29690,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#controller_fromJsonLd(doc, options);
+            v = await this.#controller_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -29757,8 +29977,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -30619,8 +30839,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -31511,8 +31731,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -32012,8 +32232,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -32352,8 +32572,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -32687,8 +32907,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -33964,7 +34184,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34059,7 +34283,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -34280,7 +34508,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34379,7 +34611,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -34637,7 +34873,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -34872,7 +35112,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35093,7 +35337,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35317,7 +35565,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35539,7 +35791,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35759,7 +36015,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -35979,7 +36239,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36197,7 +36461,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -36525,7 +36793,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36781,7 +37053,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -36880,7 +37156,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -37101,7 +37381,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -37200,7 +37484,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -38234,8 +38522,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -39793,8 +40081,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -40140,8 +40428,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -40573,7 +40861,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -40814,7 +41106,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -41137,8 +41433,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -41786,8 +42082,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -42215,8 +42511,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -42549,8 +42845,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -42889,8 +43185,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -43645,7 +43941,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#current_fromJsonLd(doc, options);
+            v = await this.#current_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -43863,7 +44163,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#first_fromJsonLd(doc, options);
+            v = await this.#first_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44081,7 +44385,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#last_fromJsonLd(doc, options);
+            v = await this.#last_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44309,7 +44617,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -44527,7 +44839,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#likesOf_fromJsonLd(doc, options);
+            v = await this.#likesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44744,7 +45060,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#sharesOf_fromJsonLd(doc, options);
+            v = await this.#sharesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -44961,7 +45281,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#repliesOf_fromJsonLd(doc, options);
+            v = await this.#repliesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45178,7 +45502,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#inboxOf_fromJsonLd(doc, options);
+            v = await this.#inboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45395,7 +45723,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#outboxOf_fromJsonLd(doc, options);
+            v = await this.#outboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45612,7 +45944,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followersOf_fromJsonLd(doc, options);
+            v = await this.#followersOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -45829,7 +46165,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followingOf_fromJsonLd(doc, options);
+            v = await this.#followingOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -46046,7 +46386,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#likedOf_fromJsonLd(doc, options);
+            v = await this.#likedOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -46712,8 +47056,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -47899,7 +48243,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#partOf_fromJsonLd(doc, options);
+            v = await this.#partOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48115,7 +48463,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#next_fromJsonLd(doc, options);
+            v = await this.#next_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48332,7 +48684,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#prev_fromJsonLd(doc, options);
+            v = await this.#prev_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -48645,8 +49001,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -49152,8 +49508,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -49486,8 +49842,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -49818,8 +50174,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -50619,8 +50975,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -51332,8 +51688,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -51667,8 +52023,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -52003,8 +52359,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -53280,7 +53636,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -53375,7 +53735,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -53596,7 +53960,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -53695,7 +54063,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -53953,7 +54325,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54188,7 +54564,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54409,7 +54789,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54633,7 +55017,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -54855,7 +55243,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55075,7 +55467,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55295,7 +55691,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -55513,7 +55913,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -55841,7 +56245,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56097,7 +56505,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56196,7 +56608,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -56417,7 +56833,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -56516,7 +56936,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -57550,8 +57974,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -59629,7 +60053,11 @@ get names(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -60084,8 +60512,8 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -60783,8 +61211,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -61120,8 +61548,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -61455,8 +61883,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -61793,8 +62221,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -62127,8 +62555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -62461,8 +62889,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -62795,8 +63223,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -63127,8 +63555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -63425,8 +63853,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -63760,8 +64188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -64195,7 +64623,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -64436,7 +64868,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -64759,8 +65195,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -65320,7 +65756,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -65565,8 +66005,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -66067,7 +66507,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -66361,8 +66805,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -67749,7 +68193,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -67844,7 +68292,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -68065,7 +68517,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68164,7 +68620,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -68422,7 +68882,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68657,7 +69121,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -68878,7 +69346,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69102,7 +69574,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69324,7 +69800,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69544,7 +70024,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69764,7 +70248,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -69982,7 +70470,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -70310,7 +70802,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70566,7 +71062,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70665,7 +71165,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -70886,7 +71390,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -70985,7 +71493,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -72019,8 +72531,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -73580,8 +74092,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -74857,7 +75369,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -74952,7 +75468,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -75173,7 +75693,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75272,7 +75796,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -75530,7 +76058,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75765,7 +76297,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -75986,7 +76522,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76210,7 +76750,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76432,7 +76976,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76652,7 +77200,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -76872,7 +77424,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77090,7 +77646,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -77418,7 +77978,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77674,7 +78238,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -77773,7 +78341,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -77994,7 +78566,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -78093,7 +78669,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -79127,8 +79707,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -81144,8 +81724,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -81782,7 +82362,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#describes_fromJsonLd(doc, options);
+            v = await this.#describes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -82025,8 +82609,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -82674,7 +83258,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+              v = await this.#exclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -82895,7 +83483,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+              v = await this.#inclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -83145,7 +83737,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -83386,7 +83982,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -83692,8 +84292,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -84392,8 +84992,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -84726,8 +85326,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -85287,7 +85887,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#subject_fromJsonLd(doc, options);
+            v = await this.#subject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85504,7 +86108,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85600,7 +86208,11 @@ relationships?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -85820,7 +86432,11 @@ relationships?: (Object | URL)[];}
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#relationship_fromJsonLd(doc, options);
+            v = await this.#relationship_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -85918,7 +86534,11 @@ relationships?: (Object | URL)[];}
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#relationship_fromJsonLd(obj, options);
+              v = await this.#relationship_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -86232,8 +86852,8 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -86749,8 +87369,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -88026,7 +88646,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88121,7 +88745,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -88342,7 +88970,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88441,7 +89073,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -88699,7 +89335,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -88934,7 +89574,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89155,7 +89799,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89379,7 +90027,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89601,7 +90253,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -89821,7 +90477,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90041,7 +90701,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90259,7 +90923,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -90587,7 +91255,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90843,7 +91515,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -90942,7 +91618,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -91163,7 +91843,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       
           }
         }
@@ -91262,7 +91946,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       
             }
           }
@@ -92296,8 +92984,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -94073,8 +94761,8 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -94505,8 +95193,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -94839,8 +95527,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -95389,8 +96077,8 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -95824,8 +96512,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -96163,8 +96851,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -96500,8 +97188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -96837,8 +97525,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {
@@ -97170,8 +97858,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   
   if ("@type" in values) {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10425,8 +10425,8 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -10693,7 +10693,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     
@@ -10728,26 +10728,26 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10786,41 +10786,41 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10857,9 +10857,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10921,18 +10921,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11018,18 +11018,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11062,9 +11062,9 @@ get urls(): ((URL | Link))[] {
             tracerProvider: options.tracerProvider,
             baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)),
+        : new URL(values["@id"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11092,9 +11092,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11125,9 +11125,9 @@ get urls(): ((URL | Link))[] {
             tracerProvider: options.tracerProvider,
             baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)),
+        : new URL(values["@id"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11155,9 +11155,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11195,18 +11195,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11246,18 +11246,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11297,18 +11297,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11367,9 +11367,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11404,9 +11404,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11441,9 +11441,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11478,9 +11478,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11564,18 +11564,18 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11636,23 +11636,23 @@ get urls(): ((URL | Link))[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))) : typeof v === "object" && "@type" in v
+        : new URL(values["@id"], options.baseUrl))) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11689,9 +11689,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11726,9 +11726,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11763,9 +11763,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11800,9 +11800,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11879,9 +11879,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11916,9 +11916,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11941,9 +11941,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11977,15 +11977,15 @@ get urls(): ((URL | Link))[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12019,9 +12019,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12056,9 +12056,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12093,9 +12093,9 @@ get urls(): ((URL | Link))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13273,8 +13273,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -14283,8 +14283,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -14336,9 +14336,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14399,9 +14399,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17372,8 +17372,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -17563,41 +17563,41 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17634,9 +17634,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17671,9 +17671,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17708,9 +17708,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17745,9 +17745,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17782,9 +17782,9 @@ instruments?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -18255,8 +18255,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -18765,8 +18765,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -18781,7 +18781,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19358,8 +19358,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -19374,7 +19374,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -20361,8 +20361,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -20414,9 +20414,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20451,9 +20451,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20818,8 +20818,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -21416,8 +21416,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -21432,7 +21432,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21452,9 +21452,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21477,9 +21477,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21502,9 +21502,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21527,9 +21527,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -22187,8 +22187,8 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -22203,7 +22203,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -22234,15 +22234,15 @@ get manualApprovals(): (URL)[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -22275,15 +22275,15 @@ get manualApprovals(): (URL)[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -23247,8 +23247,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -23300,9 +23300,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -23337,9 +23337,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23703,8 +23703,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -24619,8 +24619,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -24672,9 +24672,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24709,9 +24709,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25075,8 +25075,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -25990,8 +25990,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -26043,9 +26043,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26080,9 +26080,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26446,8 +26446,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -26898,8 +26898,8 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -26918,7 +26918,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -26949,15 +26949,15 @@ get endpoints(): (URL)[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27259,8 +27259,8 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -28084,8 +28084,8 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -28100,7 +28100,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: ("eddsa-jcs-2022")[] = [];
@@ -28150,9 +28150,9 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -29066,8 +29066,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -29082,7 +29082,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     
@@ -29116,41 +29116,41 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -29977,8 +29977,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -29993,7 +29993,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     
@@ -30027,41 +30027,41 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30839,8 +30839,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -30855,7 +30855,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -30904,15 +30904,15 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30934,9 +30934,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30959,9 +30959,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30984,9 +30984,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31731,8 +31731,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -31790,9 +31790,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31815,9 +31815,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -32232,8 +32232,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -32572,8 +32572,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -32907,8 +32907,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -38522,8 +38522,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -38599,9 +38599,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38636,9 +38636,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38693,17 +38693,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38742,17 +38742,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38789,9 +38789,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38826,9 +38826,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38863,9 +38863,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38900,9 +38900,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38937,9 +38937,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38974,9 +38974,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38999,9 +38999,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -39110,41 +39110,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -39183,41 +39183,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -39254,9 +39254,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40081,8 +40081,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -40428,8 +40428,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -41433,8 +41433,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -41486,9 +41486,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -41549,9 +41549,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -42082,8 +42082,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -42511,8 +42511,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -42845,8 +42845,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -43185,8 +43185,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -47056,8 +47056,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -47139,9 +47139,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -47176,9 +47176,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -47213,9 +47213,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -47253,18 +47253,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -47301,9 +47301,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -47338,9 +47338,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -47375,9 +47375,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -47412,9 +47412,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -47449,9 +47449,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -47486,9 +47486,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -47523,9 +47523,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -47560,9 +47560,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -49001,8 +49001,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -49058,9 +49058,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -49095,9 +49095,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -49132,9 +49132,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -49508,8 +49508,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -49842,8 +49842,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -50174,8 +50174,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -50975,8 +50975,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -50991,7 +50991,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -51022,15 +51022,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -51063,15 +51063,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -51104,15 +51104,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -51145,15 +51145,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -51186,15 +51186,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -51227,15 +51227,15 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -51688,8 +51688,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -52023,8 +52023,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -52359,8 +52359,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -57974,8 +57974,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -58051,9 +58051,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -58088,9 +58088,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -58145,17 +58145,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -58194,17 +58194,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -58241,9 +58241,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -58278,9 +58278,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -58315,9 +58315,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -58352,9 +58352,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -58389,9 +58389,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -58426,9 +58426,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -58451,9 +58451,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -58562,41 +58562,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -58635,41 +58635,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -58706,9 +58706,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -60512,8 +60512,8 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -60536,7 +60536,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -60567,15 +60567,15 @@ get names(): ((string | LanguageString))[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)));
+        : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -60726,18 +60726,18 @@ get names(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -61211,8 +61211,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -61548,8 +61548,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -61883,8 +61883,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -62221,8 +62221,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -62555,8 +62555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -62889,8 +62889,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -63223,8 +63223,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -63555,8 +63555,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -63853,8 +63853,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -64188,8 +64188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -65195,8 +65195,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -65248,9 +65248,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -65311,9 +65311,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -66005,8 +66005,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -66061,18 +66061,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -66805,8 +66805,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -66861,18 +66861,18 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72531,8 +72531,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -72608,9 +72608,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -72645,9 +72645,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -72702,17 +72702,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72751,17 +72751,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72798,9 +72798,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -72835,9 +72835,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -72872,9 +72872,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -72909,9 +72909,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -72946,9 +72946,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -72983,9 +72983,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -73008,9 +73008,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -73119,41 +73119,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -73192,41 +73192,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -73263,9 +73263,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -74092,8 +74092,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -79707,8 +79707,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -79784,9 +79784,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -79821,9 +79821,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -79878,17 +79878,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79927,17 +79927,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79974,9 +79974,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -80011,9 +80011,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -80048,9 +80048,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -80085,9 +80085,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -80122,9 +80122,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -80159,9 +80159,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -80184,9 +80184,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -80295,41 +80295,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -80368,41 +80368,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -80439,9 +80439,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -81724,8 +81724,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -81870,15 +81870,15 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))
+        : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))) : undefined
+        : new URL(values["@id"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -82609,8 +82609,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -82662,9 +82662,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -84292,8 +84292,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -84345,9 +84345,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -84382,9 +84382,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -84468,9 +84468,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -84531,9 +84531,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -84992,8 +84992,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -85326,8 +85326,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -86852,8 +86852,8 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -86905,9 +86905,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -86942,9 +86942,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -86979,9 +86979,9 @@ relationships?: (Object | URL)[];}
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -87369,8 +87369,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -92984,8 +92984,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -93061,9 +93061,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -93098,9 +93098,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -93155,17 +93155,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -93204,17 +93204,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -93251,9 +93251,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -93288,9 +93288,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -93325,9 +93325,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -93362,9 +93362,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -93399,9 +93399,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -93436,9 +93436,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -93461,9 +93461,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -93572,41 +93572,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -93645,41 +93645,41 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -93716,9 +93716,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       v,
       { ...options, baseUrl: (values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl)) }
+        : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -94761,8 +94761,8 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -94777,7 +94777,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -95193,8 +95193,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -95527,8 +95527,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -96077,8 +96077,8 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -96512,8 +96512,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -96851,8 +96851,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -97188,8 +97188,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -97525,8 +97525,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {
@@ -97858,8 +97858,8 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
   if ("@type" in values) {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10891,6 +10891,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -10938,6 +10939,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -10991,6 +10993,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11048,6 +11051,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11137,6 +11141,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11202,6 +11207,7 @@ get urls(): ((URL | Link))[] {
       
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11257,6 +11263,7 @@ get urls(): ((URL | Link))[] {
       
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11290,6 +11297,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11333,6 +11341,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11376,6 +11385,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11441,6 +11451,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11474,6 +11485,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11507,6 +11519,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11540,6 +11553,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11619,6 +11633,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11727,6 +11742,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11760,6 +11776,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11793,6 +11810,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11826,6 +11844,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -11934,6 +11953,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -12021,6 +12041,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -12054,6 +12075,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -12087,6 +12109,7 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -14342,6 +14365,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -14401,6 +14425,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -17622,6 +17647,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -17675,6 +17701,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -17708,6 +17735,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -17741,6 +17769,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -17774,6 +17803,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -17807,6 +17837,7 @@ instruments?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -20457,6 +20488,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -20490,6 +20522,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -23325,6 +23358,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -23358,6 +23392,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -24705,6 +24740,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -24738,6 +24774,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -26084,6 +26121,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -26117,6 +26155,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -28187,6 +28226,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -29155,6 +29195,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -30054,6 +30095,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38683,6 +38725,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38716,6 +38759,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38767,6 +38811,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38808,6 +38853,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38849,6 +38895,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38882,6 +38929,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38915,6 +38963,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38948,6 +38997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -38981,6 +39031,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -39014,6 +39065,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -39140,6 +39192,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -39193,6 +39246,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -39246,6 +39300,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -41493,6 +41548,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -41552,6 +41608,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47213,6 +47270,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47246,6 +47304,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47279,6 +47338,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47312,6 +47372,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47355,6 +47416,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47388,6 +47450,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47421,6 +47484,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47454,6 +47518,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47487,6 +47552,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47520,6 +47586,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47553,6 +47620,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -47586,6 +47654,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -49098,6 +49167,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -49131,6 +49201,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -49164,6 +49235,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58140,6 +58212,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58173,6 +58246,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58224,6 +58298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58265,6 +58340,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58306,6 +58382,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58339,6 +58416,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58372,6 +58450,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58405,6 +58484,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58438,6 +58518,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58471,6 +58552,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58597,6 +58679,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58650,6 +58733,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -58703,6 +58787,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -60716,6 +60801,7 @@ get names(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -65276,6 +65362,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -65335,6 +65422,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -66086,6 +66174,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -66886,6 +66975,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72716,6 +72806,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72749,6 +72840,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72800,6 +72892,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72841,6 +72934,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72882,6 +72976,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72915,6 +73010,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72948,6 +73044,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -72981,6 +73078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -73014,6 +73112,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -73047,6 +73146,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -73173,6 +73273,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -73226,6 +73327,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -73279,6 +73381,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -79887,6 +79990,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -79920,6 +80024,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -79971,6 +80076,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80012,6 +80118,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80053,6 +80160,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80086,6 +80194,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80119,6 +80228,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80152,6 +80262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80185,6 +80296,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80218,6 +80330,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80344,6 +80457,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80397,6 +80511,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -80450,6 +80565,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -82672,6 +82788,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -84374,6 +84491,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -84407,6 +84525,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -84489,6 +84608,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -84548,6 +84668,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -86952,6 +87073,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -86985,6 +87107,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -87018,6 +87141,7 @@ relationships?: (Object | URL)[];}
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93187,6 +93311,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93220,6 +93345,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93271,6 +93397,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93312,6 +93439,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93353,6 +93481,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93386,6 +93515,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93419,6 +93549,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93452,6 +93583,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93485,6 +93617,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93518,6 +93651,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93644,6 +93778,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93697,6 +93832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
@@ -93750,6 +93886,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
           !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10595,16 +10595,28 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10641,23 +10653,43 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10692,7 +10724,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10752,12 +10788,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10841,12 +10885,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10877,7 +10929,11 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10903,7 +10959,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10932,7 +10992,11 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10958,7 +11022,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10994,12 +11062,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11037,12 +11113,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11080,12 +11164,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11142,7 +11234,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11175,7 +11271,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11208,7 +11308,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11241,7 +11345,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11323,12 +11431,20 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11387,13 +11503,25 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11428,7 +11556,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11461,7 +11593,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11494,7 +11630,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11527,7 +11667,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11602,7 +11746,11 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11635,7 +11783,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11656,7 +11808,11 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11688,9 +11844,17 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11722,7 +11886,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11755,7 +11923,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11788,7 +11960,11 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -14019,7 +14195,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14078,7 +14258,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17190,23 +17374,43 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17241,7 +17445,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17274,7 +17482,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17307,7 +17519,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17340,7 +17556,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17373,7 +17593,11 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19979,7 +20203,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20012,7 +20240,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -21002,7 +21234,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21023,7 +21259,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21044,7 +21284,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21065,7 +21309,11 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21761,9 +22009,17 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21794,9 +22050,17 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22803,7 +23067,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22836,7 +23104,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24159,7 +24431,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24192,7 +24468,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25514,7 +25794,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25547,7 +25831,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26405,9 +26693,17 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27591,7 +27887,11 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28542,23 +28842,43 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -29422,23 +29742,43 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30272,9 +30612,17 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30294,7 +30642,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30315,7 +30667,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30336,7 +30692,11 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31138,7 +31498,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31159,7 +31523,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37871,7 +38239,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37904,7 +38276,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37957,11 +38333,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -37998,11 +38382,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38037,7 +38429,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38070,7 +38466,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38103,7 +38503,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38136,7 +38540,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38169,7 +38577,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38202,7 +38614,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38223,7 +38639,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38330,23 +38750,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38383,23 +38823,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38434,7 +38894,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40654,7 +41118,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40713,7 +41181,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46251,7 +46723,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46284,7 +46760,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46317,7 +46797,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46353,12 +46837,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -46393,7 +46885,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46426,7 +46922,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46459,7 +46959,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46492,7 +46996,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46525,7 +47033,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46558,7 +47070,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46591,7 +47107,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46624,7 +47144,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48106,7 +48630,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48139,7 +48667,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48172,7 +48704,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -50051,9 +50587,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50084,9 +50628,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50117,9 +50669,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50150,9 +50710,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50183,9 +50751,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50216,9 +50792,17 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56964,7 +57548,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56997,7 +57585,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57050,11 +57642,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57091,11 +57691,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57130,7 +57738,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57163,7 +57775,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57196,7 +57812,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57229,7 +57849,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57262,7 +57886,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57295,7 +57923,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57316,7 +57948,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57423,23 +58059,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57476,23 +58132,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57527,7 +58203,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59373,9 +60053,17 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59524,12 +60212,20 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -64030,7 +64726,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64089,7 +64789,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64831,12 +65535,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65619,12 +66331,20 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71290,7 +72010,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71323,7 +72047,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71376,11 +72104,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71417,11 +72153,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71456,7 +72200,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71489,7 +72237,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71522,7 +72274,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71555,7 +72311,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71588,7 +72348,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71621,7 +72385,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71642,7 +72410,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71749,23 +72521,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71802,23 +72594,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71853,7 +72665,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -78302,7 +79118,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78335,7 +79155,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78388,11 +79212,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78429,11 +79261,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78468,7 +79308,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78501,7 +79345,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78534,7 +79382,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78567,7 +79419,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78600,7 +79456,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78633,7 +79493,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78654,7 +79518,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78761,23 +79629,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78814,23 +79702,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78865,7 +79773,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80292,9 +81204,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
+          : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81072,7 +81992,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82735,7 +83659,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82768,7 +83696,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82850,7 +83782,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82909,7 +83845,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -85259,7 +86199,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85292,7 +86236,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85325,7 +86273,11 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -91335,7 +92287,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91368,7 +92324,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91421,11 +92381,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91462,11 +92430,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91501,7 +92477,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91534,7 +92514,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91567,7 +92551,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91600,7 +92588,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91633,7 +92625,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91666,7 +92662,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91687,7 +92687,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91794,23 +92798,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91847,23 +92871,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91898,7 +92942,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10892,27 +10892,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -10922,43 +10904,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10984,27 +10939,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -11013,68 +10950,23 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11100,43 +10992,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -11184,27 +11049,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -11214,30 +11061,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11309,27 +11138,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -11339,30 +11150,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11393,16 +11186,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })(),
+            baseUrl: options.baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11419,43 +11203,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11484,16 +11241,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })(),
+            baseUrl: options.baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11510,43 +11258,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11570,27 +11291,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -11600,30 +11303,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11649,27 +11334,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -11679,30 +11346,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11728,27 +11377,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -11758,30 +11389,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11829,43 +11442,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11889,43 +11475,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11949,43 +11508,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -12009,43 +11541,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -12115,27 +11620,9 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -12145,30 +11632,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -12227,40 +11696,13 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], options.baseUrl) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -12286,43 +11728,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -12346,43 +11761,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -12406,43 +11794,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -12466,43 +11827,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -12577,16 +11911,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -12610,43 +11935,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -12667,16 +11965,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -12708,27 +11997,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12751,43 +12022,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12811,43 +12055,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12871,43 +12088,16 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -15153,43 +14343,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -15239,43 +14402,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -18487,27 +17623,9 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -18516,68 +17634,23 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -18603,43 +17676,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -18663,43 +17709,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -18723,43 +17742,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -18783,43 +17775,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -18843,43 +17808,16 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -21520,43 +20458,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -21580,43 +20491,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -22619,16 +21503,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -22649,16 +21524,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -22679,16 +21545,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -22709,16 +21566,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -23424,27 +22272,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -23475,27 +22305,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -24514,43 +23326,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24574,43 +23359,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25948,43 +24706,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26008,43 +24739,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -27381,43 +26085,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -27441,43 +26118,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -28348,27 +26998,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -29556,43 +28188,16 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -30551,27 +29156,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -30580,68 +29167,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -31513,27 +30055,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -31542,68 +30066,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -32447,27 +30926,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -32487,16 +30948,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -32517,16 +30969,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -32547,16 +30990,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -33361,16 +31795,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -33391,16 +31816,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -40268,43 +38684,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -40328,43 +38717,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -40406,27 +38768,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -40435,29 +38779,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -40483,27 +38809,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -40512,29 +38820,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -40560,43 +38850,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -40620,43 +38883,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -40680,43 +38916,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -40740,43 +38949,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -40800,43 +38982,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -40860,43 +39015,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -40917,16 +39045,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -41022,27 +39141,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -41051,68 +39152,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -41138,27 +39194,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -41167,68 +39205,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -41254,43 +39247,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -43528,43 +41494,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -43614,43 +41553,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -49302,43 +47214,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -49362,43 +47247,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -49422,43 +47280,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -49482,27 +47313,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -49512,30 +47325,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -49561,43 +47356,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -49621,43 +47389,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -49681,43 +47422,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -49741,43 +47455,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -49801,43 +47488,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -49861,43 +47521,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -49921,43 +47554,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -49981,43 +47587,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -51520,43 +49099,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -51580,43 +49132,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -51640,43 +49165,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -53574,27 +51072,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -53625,27 +51105,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -53676,27 +51138,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -53727,27 +51171,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -53778,27 +51204,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -53829,27 +51237,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -60751,43 +58141,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -60811,43 +58174,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -60889,27 +58225,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -60918,29 +58236,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -60966,27 +58266,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -60995,29 +58277,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -61043,43 +58307,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -61103,43 +58340,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -61163,43 +58373,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -61223,43 +58406,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -61283,43 +58439,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -61343,43 +58472,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -61400,16 +58502,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -61505,27 +58598,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -61534,68 +58609,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -61621,27 +58651,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -61650,68 +58662,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -61737,43 +58704,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -63638,27 +60578,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })());
+          : new URL(v["@id"], options.baseUrl);
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -63795,27 +60717,9 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -63825,30 +60729,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -68391,43 +65277,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -68477,43 +65336,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -69255,27 +66087,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -69285,30 +66099,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -70091,27 +66887,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -70121,30 +66899,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -75957,43 +72717,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -76017,43 +72750,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -76095,27 +72801,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -76124,29 +72812,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -76172,27 +72842,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -76201,29 +72853,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -76249,43 +72883,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -76309,43 +72916,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -76369,43 +72949,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -76429,43 +72982,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -76489,43 +73015,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -76549,43 +73048,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -76606,16 +73078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -76711,27 +73174,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -76740,68 +73185,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -76827,27 +73227,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -76856,68 +73238,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -76943,43 +73280,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -83578,43 +79888,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -83638,43 +79921,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -83716,27 +79972,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -83745,29 +79983,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -83793,27 +80013,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -83822,29 +80024,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -83870,43 +80054,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -83930,43 +80087,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -83990,43 +80120,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -84050,43 +80153,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -84110,43 +80186,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -84170,43 +80219,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -84227,16 +80249,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -84332,27 +80345,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -84361,68 +80356,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -84448,27 +80398,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -84477,68 +80409,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -84564,43 +80451,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -86030,27 +81890,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()
+        : URL.canParse(v["@id"]) && options.baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) : undefined
+          : new URL(v["@id"], options.baseUrl) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -86831,43 +82673,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -88560,43 +84375,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -88620,43 +84408,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -88729,43 +84490,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -88815,43 +84549,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -91246,43 +86953,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -91306,43 +86986,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -91366,43 +87019,16 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -97562,43 +93188,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -97622,43 +93221,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -97700,27 +93272,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -97729,29 +93283,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -97777,27 +93313,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -97806,29 +93324,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -97854,43 +93354,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -97914,43 +93387,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -97974,43 +93420,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -98034,43 +93453,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -98094,43 +93486,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -98154,43 +93519,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -98211,16 +93549,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -98316,27 +93645,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -98345,68 +93656,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -98432,27 +93698,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
@@ -98461,68 +93709,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -98548,43 +93751,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], options.baseUrl) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })())
+            : new URL(v["@id"], options.baseUrl)
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })() }
+      { ...options, baseUrl: options.baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10569,7 +10569,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -18601,7 +18601,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19194,7 +19194,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -21244,7 +21244,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -22015,7 +22015,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -26706,7 +26706,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -27888,7 +27888,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: ("eddsa-jcs-2022")[] = [];
@@ -28866,7 +28866,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -29773,7 +29773,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -30635,7 +30635,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -50635,7 +50635,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -60108,7 +60108,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -94089,7 +94089,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10294,7 +10294,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -10595,16 +10595,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10641,23 +10641,23 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10692,7 +10692,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10752,12 +10752,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10841,12 +10841,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10877,7 +10877,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
+            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10903,7 +10903,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10932,7 +10932,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
+            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10958,7 +10958,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10994,12 +10994,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11037,12 +11037,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11080,12 +11080,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11142,7 +11142,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11175,7 +11175,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11208,7 +11208,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11241,7 +11241,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11323,12 +11323,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11387,13 +11387,13 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11428,7 +11428,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11461,7 +11461,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11494,7 +11494,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11527,7 +11527,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11602,7 +11602,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11635,7 +11635,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11656,7 +11656,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11688,9 +11688,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11722,7 +11722,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11755,7 +11755,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11788,7 +11788,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -12966,7 +12966,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -13968,7 +13968,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -14019,7 +14019,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14078,7 +14078,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17001,7 +17001,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -17190,23 +17190,23 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17241,7 +17241,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17274,7 +17274,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17307,7 +17307,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17340,7 +17340,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17373,7 +17373,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17844,7 +17844,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18347,7 +18347,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18933,7 +18933,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -19928,7 +19928,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -19979,7 +19979,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20012,7 +20012,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20377,7 +20377,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -20968,7 +20968,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -21002,7 +21002,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21023,7 +21023,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21044,7 +21044,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21065,7 +21065,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21716,7 +21716,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -21761,9 +21761,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21794,9 +21794,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22752,7 +22752,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -22803,7 +22803,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22836,7 +22836,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23200,7 +23200,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -24108,7 +24108,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -24159,7 +24159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24192,7 +24192,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24556,7 +24556,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -25463,7 +25463,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -25514,7 +25514,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25547,7 +25547,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25911,7 +25911,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -26356,7 +26356,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -26405,9 +26405,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26709,7 +26709,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -27527,7 +27527,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -27591,7 +27591,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28494,7 +28494,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -28542,23 +28542,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -29374,7 +29374,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -29422,23 +29422,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30209,7 +30209,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -30272,9 +30272,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30294,7 +30294,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30315,7 +30315,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30336,7 +30336,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31081,7 +31081,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -31138,7 +31138,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31159,7 +31159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31574,7 +31574,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -31914,7 +31914,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -32249,7 +32249,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -37796,7 +37796,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -37871,7 +37871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37904,7 +37904,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37957,11 +37957,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -37998,11 +37998,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38037,7 +38037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38070,7 +38070,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38103,7 +38103,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38136,7 +38136,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38169,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38202,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38223,7 +38223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38330,23 +38330,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38383,23 +38383,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38434,7 +38434,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39259,7 +39259,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -39606,7 +39606,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -40603,7 +40603,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -40654,7 +40654,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40713,7 +40713,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41244,7 +41244,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -41673,7 +41673,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -42007,7 +42007,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -42347,7 +42347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -46170,7 +46170,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -46251,7 +46251,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46284,7 +46284,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46317,7 +46317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46353,12 +46353,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -46393,7 +46393,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46426,7 +46426,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46459,7 +46459,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46492,7 +46492,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46525,7 +46525,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46558,7 +46558,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46591,7 +46591,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46624,7 +46624,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48051,7 +48051,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -48106,7 +48106,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48139,7 +48139,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48172,7 +48172,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48546,7 +48546,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -48880,7 +48880,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -49212,7 +49212,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -50006,7 +50006,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -50051,9 +50051,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50084,9 +50084,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50117,9 +50117,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50150,9 +50150,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50183,9 +50183,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50216,9 +50216,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50671,7 +50671,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -51006,7 +51006,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -51342,7 +51342,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -56889,7 +56889,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -56964,7 +56964,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56997,7 +56997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57050,11 +57050,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57091,11 +57091,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57130,7 +57130,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57163,7 +57163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57196,7 +57196,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57229,7 +57229,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57262,7 +57262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57295,7 +57295,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57316,7 +57316,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57423,23 +57423,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57476,23 +57476,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57527,7 +57527,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59320,7 +59320,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -59373,9 +59373,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59524,12 +59524,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -60003,7 +60003,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60340,7 +60340,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60675,7 +60675,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61013,7 +61013,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61347,7 +61347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61681,7 +61681,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62015,7 +62015,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62347,7 +62347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62645,7 +62645,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62980,7 +62980,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -63979,7 +63979,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -64030,7 +64030,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64089,7 +64089,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64777,7 +64777,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -64831,12 +64831,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65565,7 +65565,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -65619,12 +65619,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71215,7 +71215,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -71290,7 +71290,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71323,7 +71323,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71376,11 +71376,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71417,11 +71417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71456,7 +71456,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71489,7 +71489,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71522,7 +71522,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71555,7 +71555,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71588,7 +71588,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71621,7 +71621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71642,7 +71642,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71749,23 +71749,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71802,23 +71802,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71853,7 +71853,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72680,7 +72680,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -78227,7 +78227,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -78302,7 +78302,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78335,7 +78335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78388,11 +78388,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78429,11 +78429,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78468,7 +78468,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78501,7 +78501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78534,7 +78534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78567,7 +78567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78600,7 +78600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78633,7 +78633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78654,7 +78654,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78761,23 +78761,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78814,23 +78814,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78865,7 +78865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80148,7 +80148,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -80292,9 +80292,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : undefined
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81021,7 +81021,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -81072,7 +81072,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82684,7 +82684,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -82735,7 +82735,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82768,7 +82768,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82850,7 +82850,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82909,7 +82909,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83368,7 +83368,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -83702,7 +83702,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -85208,7 +85208,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -85259,7 +85259,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85292,7 +85292,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85325,7 +85325,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -85713,7 +85713,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -91260,7 +91260,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -91335,7 +91335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91368,7 +91368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91421,11 +91421,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91462,11 +91462,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91501,7 +91501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91534,7 +91534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91567,7 +91567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91600,7 +91600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91633,7 +91633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91666,7 +91666,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91687,7 +91687,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91794,23 +91794,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91847,23 +91847,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91898,7 +91898,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -92934,7 +92934,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -93366,7 +93366,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -93700,7 +93700,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94250,7 +94250,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94685,7 +94685,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95024,7 +95024,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95361,7 +95361,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95698,7 +95698,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -96031,7 +96031,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -2336,7 +2336,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "attachment"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#attachment_fromJsonLd(obj, options);
+              v = await this.#attachment_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -2590,7 +2594,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "attributedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#attribution_fromJsonLd(doc, options);
+            v = await this.#attribution_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -2686,7 +2694,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "attributedTo"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#attribution_fromJsonLd(obj, options);
+              v = await this.#attribution_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -2903,7 +2915,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "audience"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#audience_fromJsonLd(doc, options);
+            v = await this.#audience_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -2998,7 +3014,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "audience"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#audience_fromJsonLd(obj, options);
+              v = await this.#audience_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3259,7 +3279,11 @@ get contents(): ((string | LanguageString))[] {
               "context"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#context_fromJsonLd(obj, options);
+              v = await this.#context_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3527,7 +3551,11 @@ get names(): ((string | LanguageString))[] {
               "generator"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#generator_fromJsonLd(obj, options);
+              v = await this.#generator_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -3764,7 +3792,11 @@ get names(): ((string | LanguageString))[] {
             "icon"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#icon_fromJsonLd(doc, options);
+            v = await this.#icon_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -3860,7 +3892,11 @@ get names(): ((string | LanguageString))[] {
               "icon"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#icon_fromJsonLd(obj, options);
+              v = await this.#icon_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4097,7 +4133,11 @@ get names(): ((string | LanguageString))[] {
             "image"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#image_fromJsonLd(doc, options);
+            v = await this.#image_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4193,7 +4233,11 @@ get names(): ((string | LanguageString))[] {
               "image"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#image_fromJsonLd(obj, options);
+              v = await this.#image_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4419,7 +4463,11 @@ get names(): ((string | LanguageString))[] {
             "inReplyTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#replyTarget_fromJsonLd(doc, options);
+            v = await this.#replyTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4514,7 +4562,11 @@ get names(): ((string | LanguageString))[] {
               "inReplyTo"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#replyTarget_fromJsonLd(obj, options);
+              v = await this.#replyTarget_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -4740,7 +4792,11 @@ get names(): ((string | LanguageString))[] {
             "location"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#location_fromJsonLd(doc, options);
+            v = await this.#location_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -4835,7 +4891,11 @@ get names(): ((string | LanguageString))[] {
               "location"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#location_fromJsonLd(obj, options);
+              v = await this.#location_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -5060,7 +5120,11 @@ get names(): ((string | LanguageString))[] {
             "preview"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#preview_fromJsonLd(doc, options);
+            v = await this.#preview_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5154,7 +5218,11 @@ get names(): ((string | LanguageString))[] {
               "preview"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -5384,7 +5452,11 @@ get names(): ((string | LanguageString))[] {
             "replies"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#replies_fromJsonLd(doc, options);
+            v = await this.#replies_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5606,7 +5678,11 @@ get names(): ((string | LanguageString))[] {
             "shares"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#shares_fromJsonLd(doc, options);
+            v = await this.#shares_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -5828,7 +5904,11 @@ get names(): ((string | LanguageString))[] {
             "likes"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likes_fromJsonLd(doc, options);
+            v = await this.#likes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6044,7 +6124,11 @@ get names(): ((string | LanguageString))[] {
             "emojiReactions"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#emojiReactions_fromJsonLd(doc, options);
+            v = await this.#emojiReactions_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6312,7 +6396,11 @@ get summaries(): ((string | LanguageString))[] {
               "tag"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#tag_fromJsonLd(obj, options);
+              v = await this.#tag_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -6563,7 +6651,11 @@ get urls(): ((URL | Link))[] {
             "to"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#to_fromJsonLd(doc, options);
+            v = await this.#to_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6658,7 +6750,11 @@ get urls(): ((URL | Link))[] {
               "to"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#to_fromJsonLd(obj, options);
+              v = await this.#to_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -6875,7 +6971,11 @@ get urls(): ((URL | Link))[] {
             "bto"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#bto_fromJsonLd(doc, options);
+            v = await this.#bto_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -6970,7 +7070,11 @@ get urls(): ((URL | Link))[] {
               "bto"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#bto_fromJsonLd(obj, options);
+              v = await this.#bto_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7187,7 +7291,11 @@ get urls(): ((URL | Link))[] {
             "cc"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#cc_fromJsonLd(doc, options);
+            v = await this.#cc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7282,7 +7390,11 @@ get urls(): ((URL | Link))[] {
               "cc"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#cc_fromJsonLd(obj, options);
+              v = await this.#cc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7499,7 +7611,11 @@ get urls(): ((URL | Link))[] {
             "bcc"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#bcc_fromJsonLd(doc, options);
+            v = await this.#bcc_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7594,7 +7710,11 @@ get urls(): ((URL | Link))[] {
               "bcc"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#bcc_fromJsonLd(obj, options);
+              v = await this.#bcc_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -7874,7 +7994,11 @@ get urls(): ((URL | Link))[] {
             "proof"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#proof_fromJsonLd(doc, options);
+            v = await this.#proof_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -7968,7 +8092,11 @@ get urls(): ((URL | Link))[] {
               "proof"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#proof_fromJsonLd(obj, options);
+              v = await this.#proof_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -8224,7 +8352,11 @@ get urls(): ((URL | Link))[] {
             "likeAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likeAuthorization_fromJsonLd(doc, options);
+            v = await this.#likeAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -8440,7 +8572,11 @@ get urls(): ((URL | Link))[] {
             "replyAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#replyAuthorization_fromJsonLd(doc, options);
+            v = await this.#replyAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -8656,7 +8792,11 @@ get urls(): ((URL | Link))[] {
             "announceAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#announceAuthorization_fromJsonLd(doc, options);
+            v = await this.#announceAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -10204,7 +10344,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -10505,16 +10645,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10551,23 +10691,23 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10602,7 +10742,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10662,12 +10802,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10751,12 +10891,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10787,7 +10927,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10813,7 +10953,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10842,7 +10982,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10868,7 +11008,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10904,12 +11044,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10947,12 +11087,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10990,12 +11130,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11052,7 +11192,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11085,7 +11225,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11118,7 +11258,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11151,7 +11291,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11233,12 +11373,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11297,13 +11437,13 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11338,7 +11478,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11371,7 +11511,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11404,7 +11544,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11437,7 +11577,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11512,7 +11652,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11545,7 +11685,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11566,7 +11706,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11598,9 +11738,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11632,7 +11772,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11665,7 +11805,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11698,7 +11838,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -12876,7 +13016,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -13313,7 +13453,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -13552,7 +13696,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -13874,7 +14022,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -13925,7 +14073,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -13984,7 +14132,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -14930,7 +15078,11 @@ instruments?: (Object | URL)[];}
             "actor"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#actor_fromJsonLd(doc, options);
+            v = await this.#actor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15026,7 +15178,11 @@ instruments?: (Object | URL)[];}
               "actor"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#actor_fromJsonLd(obj, options);
+              v = await this.#actor_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15244,7 +15400,11 @@ instruments?: (Object | URL)[];}
             "object"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15340,7 +15500,11 @@ instruments?: (Object | URL)[];}
               "object"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15561,7 +15725,11 @@ instruments?: (Object | URL)[];}
             "target"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#target_fromJsonLd(doc, options);
+            v = await this.#target_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15660,7 +15828,11 @@ instruments?: (Object | URL)[];}
               "target"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#target_fromJsonLd(obj, options);
+              v = await this.#target_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -15878,7 +16050,11 @@ instruments?: (Object | URL)[];}
             "result"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#result_fromJsonLd(doc, options);
+            v = await this.#result_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -15974,7 +16150,11 @@ instruments?: (Object | URL)[];}
               "result"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#result_fromJsonLd(obj, options);
+              v = await this.#result_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16193,7 +16373,11 @@ instruments?: (Object | URL)[];}
             "origin"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#origin_fromJsonLd(doc, options);
+            v = await this.#origin_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -16290,7 +16474,11 @@ instruments?: (Object | URL)[];}
               "origin"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#origin_fromJsonLd(obj, options);
+              v = await this.#origin_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16507,7 +16695,11 @@ instruments?: (Object | URL)[];}
             "instrument"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#instrument_fromJsonLd(doc, options);
+            v = await this.#instrument_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -16602,7 +16794,11 @@ instruments?: (Object | URL)[];}
               "instrument"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#instrument_fromJsonLd(obj, options);
+              v = await this.#instrument_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -16883,7 +17079,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -17072,23 +17268,23 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17123,7 +17319,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17156,7 +17352,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17189,7 +17385,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17222,7 +17418,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17255,7 +17451,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17726,7 +17922,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18229,7 +18425,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18815,7 +19011,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -19314,7 +19510,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -19529,7 +19729,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -19806,7 +20010,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -19857,7 +20061,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -19890,7 +20094,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20255,7 +20459,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -20846,7 +21050,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -20880,7 +21084,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -20901,7 +21105,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -20922,7 +21126,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -20943,7 +21147,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21594,7 +21798,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -21639,9 +21843,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21672,9 +21876,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22134,7 +22338,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -22349,7 +22557,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -22626,7 +22838,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -22677,7 +22889,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22710,7 +22922,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23074,7 +23286,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -23486,7 +23698,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -23701,7 +23917,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -23978,7 +24198,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -24029,7 +24249,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24062,7 +24282,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24426,7 +24646,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -24837,7 +25057,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactingObject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactingObject_fromJsonLd(doc, options);
+            v = await this.#interactingObject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -25052,7 +25276,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "interactionTarget"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#interactionTarget_fromJsonLd(doc, options);
+            v = await this.#interactionTarget_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -25329,7 +25557,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -25380,7 +25608,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25413,7 +25641,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25777,7 +26005,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -26222,7 +26450,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -26271,9 +26499,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26575,7 +26803,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -27393,7 +27621,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -27457,7 +27685,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28083,7 +28311,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
             "owner"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#owner_fromJsonLd(doc, options);
+            v = await this.#owner_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -28358,7 +28590,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -28406,23 +28638,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -28954,7 +29186,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
             "controller"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#controller_fromJsonLd(doc, options);
+            v = await this.#controller_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -29236,7 +29472,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -29284,23 +29520,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30071,7 +30307,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -30134,9 +30370,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30156,7 +30392,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30177,7 +30413,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30198,7 +30434,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -30943,7 +31179,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -31000,7 +31236,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31021,7 +31257,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31436,7 +31672,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -31776,7 +32012,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -32111,7 +32347,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -33387,7 +33623,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -33480,7 +33720,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -33699,7 +33943,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -33796,7 +34044,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -34052,7 +34304,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34285,7 +34541,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34504,7 +34764,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34726,7 +34990,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -34946,7 +35214,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35164,7 +35436,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35382,7 +35658,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -35598,7 +35878,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -35924,7 +36208,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36178,7 +36466,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36275,7 +36567,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -36494,7 +36790,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -36591,7 +36891,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -37624,7 +37928,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -37699,7 +38003,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37732,7 +38036,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37785,11 +38089,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -37826,11 +38130,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -37865,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -37898,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -37931,7 +38235,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -37964,7 +38268,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -37997,7 +38301,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38030,7 +38334,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38051,7 +38355,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38158,23 +38462,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38211,23 +38515,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38262,7 +38566,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39087,7 +39391,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -39434,7 +39738,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -39866,7 +40170,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -40105,7 +40413,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -40427,7 +40739,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -40478,7 +40790,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40537,7 +40849,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41068,7 +41380,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -41497,7 +41809,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -41831,7 +42143,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -42171,7 +42483,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -42926,7 +43238,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "current"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#current_fromJsonLd(doc, options);
+            v = await this.#current_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43142,7 +43458,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "first"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#first_fromJsonLd(doc, options);
+            v = await this.#first_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43358,7 +43678,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "last"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#last_fromJsonLd(doc, options);
+            v = await this.#last_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -43584,7 +43908,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "items"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -43800,7 +44128,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "likesOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likesOf_fromJsonLd(doc, options);
+            v = await this.#likesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44015,7 +44347,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "sharesOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#sharesOf_fromJsonLd(doc, options);
+            v = await this.#sharesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44230,7 +44566,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "repliesOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#repliesOf_fromJsonLd(doc, options);
+            v = await this.#repliesOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44445,7 +44785,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "inboxOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inboxOf_fromJsonLd(doc, options);
+            v = await this.#inboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44660,7 +45004,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "outboxOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outboxOf_fromJsonLd(doc, options);
+            v = await this.#outboxOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -44875,7 +45223,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "followersOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followersOf_fromJsonLd(doc, options);
+            v = await this.#followersOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45090,7 +45442,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "followingOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followingOf_fromJsonLd(doc, options);
+            v = await this.#followingOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45305,7 +45661,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "likedOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#likedOf_fromJsonLd(doc, options);
+            v = await this.#likedOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -45970,7 +46330,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -46051,7 +46411,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46084,7 +46444,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46117,7 +46477,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46153,12 +46513,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -46193,7 +46553,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46226,7 +46586,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46259,7 +46619,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46292,7 +46652,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46325,7 +46685,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46358,7 +46718,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46391,7 +46751,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46424,7 +46784,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47104,7 +47464,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "partOf"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#partOf_fromJsonLd(doc, options);
+            v = await this.#partOf_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47318,7 +47682,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "next"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#next_fromJsonLd(doc, options);
+            v = await this.#next_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47533,7 +47901,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "prev"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#prev_fromJsonLd(doc, options);
+            v = await this.#prev_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -47845,7 +48217,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -47900,7 +48272,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -47933,7 +48305,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -47966,7 +48338,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48340,7 +48712,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -48674,7 +49046,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -49006,7 +49378,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -49800,7 +50172,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -49845,9 +50217,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -49878,9 +50250,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -49911,9 +50283,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -49944,9 +50316,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -49977,9 +50349,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50010,9 +50382,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50465,7 +50837,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -50800,7 +51172,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -51136,7 +51508,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -52412,7 +52784,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -52505,7 +52881,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -52724,7 +53104,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -52821,7 +53205,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -53077,7 +53465,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53310,7 +53702,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53529,7 +53925,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53751,7 +54151,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -53971,7 +54375,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54189,7 +54597,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54407,7 +54819,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -54623,7 +55039,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -54949,7 +55369,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55203,7 +55627,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55300,7 +55728,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -55519,7 +55951,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -55616,7 +56052,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -56649,7 +57089,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -56724,7 +57164,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56757,7 +57197,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -56810,11 +57250,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -56851,11 +57291,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -56890,7 +57330,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -56923,7 +57363,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -56956,7 +57396,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -56989,7 +57429,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57022,7 +57462,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57055,7 +57495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57076,7 +57516,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57183,23 +57623,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57236,23 +57676,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57287,7 +57727,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -58624,7 +59064,11 @@ get names(): ((string | LanguageString))[] {
               "preview"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#preview_fromJsonLd(obj, options);
+              v = await this.#preview_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -59078,7 +59522,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -59131,9 +59575,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59282,12 +59726,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -59761,7 +60205,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60098,7 +60542,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60433,7 +60877,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60771,7 +61215,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61105,7 +61549,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61439,7 +61883,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61773,7 +62217,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62105,7 +62549,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62403,7 +62847,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62738,7 +63182,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -63172,7 +63616,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -63411,7 +63859,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -63733,7 +64185,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -63784,7 +64236,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -63843,7 +64295,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64285,7 +64737,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "orderedItems"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -64529,7 +64985,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -64583,12 +65039,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65022,7 +65478,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               "orderedItems"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#item_fromJsonLd(obj, options);
+              v = await this.#item_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -65315,7 +65775,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -65369,12 +65829,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -66694,7 +67154,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -66787,7 +67251,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -67006,7 +67474,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67103,7 +67575,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -67359,7 +67835,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67592,7 +68072,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -67811,7 +68295,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68033,7 +68521,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68253,7 +68745,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68471,7 +68967,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68689,7 +69189,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -68905,7 +69409,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -69231,7 +69739,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69485,7 +69997,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69582,7 +70098,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -69801,7 +70321,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -69898,7 +70422,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -70931,7 +71459,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -71006,7 +71534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71039,7 +71567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71092,11 +71620,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71133,11 +71661,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71172,7 +71700,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71205,7 +71733,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71238,7 +71766,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71271,7 +71799,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71304,7 +71832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71337,7 +71865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71358,7 +71886,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71465,23 +71993,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71518,23 +72046,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71569,7 +72097,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72396,7 +72924,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -73672,7 +74200,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -73765,7 +74297,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -73984,7 +74520,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74081,7 +74621,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -74337,7 +74881,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74570,7 +75118,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -74789,7 +75341,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75011,7 +75567,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75231,7 +75791,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75449,7 +76013,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75667,7 +76235,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -75883,7 +76455,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -76209,7 +76785,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76463,7 +77043,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76560,7 +77144,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -76779,7 +77367,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -76876,7 +77468,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -77909,7 +78505,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -77984,7 +78580,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78017,7 +78613,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78070,11 +78666,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78111,11 +78707,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78150,7 +78746,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78183,7 +78779,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78216,7 +78812,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78249,7 +78845,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78282,7 +78878,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78315,7 +78911,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78336,7 +78932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78443,23 +79039,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78496,23 +79092,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78547,7 +79143,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -79830,7 +80426,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -79974,9 +80570,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -80459,7 +81055,11 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
             "describes"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#describes_fromJsonLd(doc, options);
+            v = await this.#describes_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -80701,7 +81301,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -80752,7 +81352,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -81345,7 +81945,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               "oneOf"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#exclusiveOption_fromJsonLd(obj, options);
+              v = await this.#exclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -81564,7 +82168,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
               "anyOf"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#inclusiveOption_fromJsonLd(obj, options);
+              v = await this.#inclusiveOption_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -81812,7 +82420,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             "quote"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quote_fromJsonLd(doc, options);
+            v = await this.#quote_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -82051,7 +82663,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
             "quoteAuthorization"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#quoteAuthorization_fromJsonLd(doc, options);
+            v = await this.#quoteAuthorization_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -82356,7 +82972,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -82407,7 +83023,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82440,7 +83056,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82522,7 +83138,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82581,7 +83197,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83040,7 +83656,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -83374,7 +83990,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -83934,7 +84550,11 @@ relationships?: (Object | URL)[];}
             "subject"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#subject_fromJsonLd(doc, options);
+            v = await this.#subject_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84149,7 +84769,11 @@ relationships?: (Object | URL)[];}
             "object"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#object_fromJsonLd(doc, options);
+            v = await this.#object_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84243,7 +84867,11 @@ relationships?: (Object | URL)[];}
               "object"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#object_fromJsonLd(obj, options);
+              v = await this.#object_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -84461,7 +85089,11 @@ relationships?: (Object | URL)[];}
             "relationship"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#relationship_fromJsonLd(doc, options);
+            v = await this.#relationship_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -84557,7 +85189,11 @@ relationships?: (Object | URL)[];}
               "relationship"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#relationship_fromJsonLd(obj, options);
+              v = await this.#relationship_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -84870,7 +85506,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -84921,7 +85557,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -84954,7 +85590,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -84987,7 +85623,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -85375,7 +86011,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -86651,7 +87287,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "publicKey"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#publicKey_fromJsonLd(doc, options);
+            v = await this.#publicKey_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -86744,7 +87384,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "publicKey"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#publicKey_fromJsonLd(obj, options);
+              v = await this.#publicKey_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -86963,7 +87607,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "assertionMethod"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#assertionMethod_fromJsonLd(doc, options);
+            v = await this.#assertionMethod_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87060,7 +87708,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "assertionMethod"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#assertionMethod_fromJsonLd(obj, options);
+              v = await this.#assertionMethod_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -87316,7 +87968,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "inbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#inbox_fromJsonLd(doc, options);
+            v = await this.#inbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87549,7 +88205,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "outbox"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#outbox_fromJsonLd(doc, options);
+            v = await this.#outbox_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87768,7 +88428,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "following"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#following_fromJsonLd(doc, options);
+            v = await this.#following_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -87990,7 +88654,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "followers"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#followers_fromJsonLd(doc, options);
+            v = await this.#followers_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88210,7 +88878,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "liked"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#liked_fromJsonLd(doc, options);
+            v = await this.#liked_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88428,7 +89100,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featured"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featured_fromJsonLd(doc, options);
+            v = await this.#featured_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88646,7 +89322,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "featuredTags"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#featuredTags_fromJsonLd(doc, options);
+            v = await this.#featuredTags_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -88862,7 +89542,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "streams"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#stream_fromJsonLd(obj, options);
+              v = await this.#stream_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -89188,7 +89872,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "movedTo"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#successor_fromJsonLd(doc, options);
+            v = await this.#successor_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89442,7 +90130,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "alsoKnownAs"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#alias_fromJsonLd(doc, options);
+            v = await this.#alias_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89539,7 +90231,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "alsoKnownAs"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#alias_fromJsonLd(obj, options);
+              v = await this.#alias_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -89758,7 +90454,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
             "service"];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#service_fromJsonLd(doc, options);
+            v = await this.#service_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         
@@ -89855,7 +90555,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
               "service"];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#service_fromJsonLd(obj, options);
+              v = await this.#service_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         
@@ -90888,7 +91592,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -90963,7 +91667,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -90996,7 +91700,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91049,11 +91753,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91090,11 +91794,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91129,7 +91833,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91162,7 +91866,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91195,7 +91899,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91228,7 +91932,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91261,7 +91965,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91294,7 +91998,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91315,7 +92019,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91422,23 +92126,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91475,23 +92179,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91526,7 +92230,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -92562,7 +93266,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -92994,7 +93698,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -93328,7 +94032,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -93878,7 +94582,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94313,7 +95017,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94652,7 +95356,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94989,7 +95693,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95326,7 +96030,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95659,7 +96363,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10344,9 +10344,14 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -10645,16 +10650,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10691,23 +10696,23 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10742,7 +10747,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10802,12 +10807,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10891,12 +10896,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10927,7 +10932,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
+            baseUrl: _baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10953,7 +10958,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10982,7 +10987,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
+            baseUrl: _baseUrl,
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11008,7 +11013,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11044,12 +11049,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11087,12 +11092,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11130,12 +11135,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11192,7 +11197,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11225,7 +11230,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11258,7 +11263,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11291,7 +11296,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11373,12 +11378,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11437,13 +11442,13 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], _baseUrl) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11478,7 +11483,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11511,7 +11516,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11544,7 +11549,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11577,7 +11582,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11652,7 +11657,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11685,7 +11690,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11706,7 +11711,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11738,9 +11743,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11772,7 +11777,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11805,7 +11810,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11838,7 +11843,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13016,9 +13021,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -14022,9 +14032,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -14073,7 +14088,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14132,7 +14147,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17079,9 +17094,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -17268,23 +17288,23 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17319,7 +17339,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17352,7 +17372,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17385,7 +17405,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17418,7 +17438,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17451,7 +17471,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -17922,9 +17942,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -18425,9 +18450,14 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -19011,9 +19041,14 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -20010,9 +20045,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -20061,7 +20101,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20094,7 +20134,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20459,9 +20499,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -21050,9 +21095,14 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -21084,7 +21134,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21105,7 +21155,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21126,7 +21176,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21147,7 +21197,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21798,9 +21848,14 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -21843,9 +21898,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21876,9 +21931,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22838,9 +22893,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -22889,7 +22949,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22922,7 +22982,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -23286,9 +23346,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -24198,9 +24263,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -24249,7 +24319,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24282,7 +24352,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24646,9 +24716,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -25557,9 +25632,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -25608,7 +25688,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25641,7 +25721,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26005,9 +26085,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -26450,9 +26535,14 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -26499,9 +26589,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -26803,9 +26893,14 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -27621,9 +27716,14 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -27685,7 +27785,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28590,9 +28690,14 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -28638,23 +28743,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -29472,9 +29577,14 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -29520,23 +29630,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30307,9 +30417,14 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -30370,9 +30485,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30392,7 +30507,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30413,7 +30528,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30434,7 +30549,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31179,9 +31294,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -31236,7 +31356,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31257,7 +31377,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -31672,9 +31792,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -32012,9 +32137,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -32347,9 +32477,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -37928,9 +38063,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -38003,7 +38143,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -38036,7 +38176,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -38089,11 +38229,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38130,11 +38270,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38169,7 +38309,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38202,7 +38342,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38235,7 +38375,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38268,7 +38408,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38301,7 +38441,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38334,7 +38474,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38355,7 +38495,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38462,23 +38602,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38515,23 +38655,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38566,7 +38706,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -39391,9 +39531,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -39738,9 +39883,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -40739,9 +40889,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -40790,7 +40945,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40849,7 +41004,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -41380,9 +41535,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -41809,9 +41969,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -42143,9 +42308,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -42483,9 +42653,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -46330,9 +46505,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -46411,7 +46591,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46444,7 +46624,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46477,7 +46657,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46513,12 +46693,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -46553,7 +46733,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46586,7 +46766,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46619,7 +46799,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46652,7 +46832,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46685,7 +46865,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46718,7 +46898,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46751,7 +46931,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46784,7 +46964,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48217,9 +48397,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -48272,7 +48457,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48305,7 +48490,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48338,7 +48523,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -48712,9 +48897,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -49046,9 +49236,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -49378,9 +49573,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -50172,9 +50372,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -50217,9 +50422,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50250,9 +50455,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50283,9 +50488,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50316,9 +50521,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50349,9 +50554,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50382,9 +50587,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -50837,9 +51042,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -51172,9 +51382,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -51508,9 +51723,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -57089,9 +57309,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -57164,7 +57389,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -57197,7 +57422,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57250,11 +57475,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57291,11 +57516,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57330,7 +57555,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57363,7 +57588,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57396,7 +57621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57429,7 +57654,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57462,7 +57687,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57495,7 +57720,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57516,7 +57741,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57623,23 +57848,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57676,23 +57901,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57727,7 +57952,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59522,9 +59747,14 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -59575,9 +59805,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], _baseUrl);
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59726,12 +59956,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -60205,9 +60435,14 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -60542,9 +60777,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -60877,9 +61117,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -61215,9 +61460,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -61549,9 +61799,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -61883,9 +62138,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -62217,9 +62477,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -62549,9 +62814,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -62847,9 +63117,14 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -63182,9 +63457,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -64185,9 +64465,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -64236,7 +64521,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64295,7 +64580,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64985,9 +65270,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -65039,12 +65329,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65775,9 +66065,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -65829,12 +66124,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71459,9 +71754,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -71534,7 +71834,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71567,7 +71867,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71620,11 +71920,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71661,11 +71961,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71700,7 +72000,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71733,7 +72033,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71766,7 +72066,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71799,7 +72099,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71832,7 +72132,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71865,7 +72165,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71886,7 +72186,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71993,23 +72293,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72046,23 +72346,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -72097,7 +72397,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -72924,9 +73224,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -78505,9 +78810,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -78580,7 +78890,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78613,7 +78923,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78666,11 +78976,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78707,11 +79017,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78746,7 +79056,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78779,7 +79089,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78812,7 +79122,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78845,7 +79155,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78878,7 +79188,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78911,7 +79221,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78932,7 +79242,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -79039,23 +79349,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79092,23 +79402,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -79143,7 +79453,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80426,9 +80736,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -80570,9 +80885,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && _baseUrl
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : undefined
+          : new URL(v["@id"], _baseUrl) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81301,9 +81616,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -81352,7 +81672,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82972,9 +83292,14 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -83023,7 +83348,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -83056,7 +83381,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -83138,7 +83463,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -83197,7 +83522,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -83656,9 +83981,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -83990,9 +84320,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -85506,9 +85841,14 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -85557,7 +85897,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85590,7 +85930,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85623,7 +85963,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -86011,9 +86351,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -91592,9 +91937,14 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -91667,7 +92017,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91700,7 +92050,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91753,11 +92103,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91794,11 +92144,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91833,7 +92183,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91866,7 +92216,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91899,7 +92249,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91932,7 +92282,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91965,7 +92315,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91998,7 +92348,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -92019,7 +92369,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -92126,23 +92476,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -92179,23 +92529,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -92230,7 +92580,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: _baseUrl }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -93266,9 +93616,14 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -93698,9 +94053,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -94032,9 +94392,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -94582,9 +94947,14 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -95017,9 +95387,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -95356,9 +95731,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -95693,9 +96073,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -96030,9 +96415,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);
@@ -96363,9 +96753,14 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   
   if ("@type" in values) {
     span.setAttribute("activitypub.object.type", values["@type"]);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -3679,23 +3679,25 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === "object") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       
-          {
-            const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as Image;
-          }
+            {
+              const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as Image;
+            }
         
+          }
         }
       
         try {
@@ -4024,23 +4026,25 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === "object") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       
-          {
-            const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as Image;
-          }
+            {
+              const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as Image;
+            }
         
+          }
         }
       
         try {
@@ -10591,16 +10595,16 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10637,23 +10641,23 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10688,7 +10692,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10748,12 +10752,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10837,12 +10841,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10873,7 +10877,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10899,7 +10903,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10928,7 +10932,7 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10954,7 +10958,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -10990,12 +10994,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11033,12 +11037,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11076,12 +11080,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11138,7 +11142,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11171,7 +11175,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11204,7 +11208,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11237,7 +11241,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11319,12 +11323,12 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11383,13 +11387,13 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11424,7 +11428,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11457,7 +11461,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11490,7 +11494,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11523,7 +11527,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11598,7 +11602,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11631,7 +11635,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11652,7 +11656,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11684,9 +11688,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11718,7 +11722,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11751,7 +11755,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11784,7 +11788,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -14015,7 +14019,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14074,7 +14078,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17186,23 +17190,23 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17237,7 +17241,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17270,7 +17274,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17303,7 +17307,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17336,7 +17340,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17369,7 +17373,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19975,7 +19979,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20008,7 +20012,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20998,7 +21002,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21019,7 +21023,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21040,7 +21044,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21061,7 +21065,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21757,9 +21761,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21790,9 +21794,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22799,7 +22803,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22832,7 +22836,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24155,7 +24159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24188,7 +24192,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25510,7 +25514,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25543,7 +25547,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26401,9 +26405,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27587,7 +27591,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -28538,23 +28542,23 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -29418,23 +29422,23 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30268,9 +30272,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30290,7 +30294,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30311,7 +30315,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30332,7 +30336,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31134,7 +31138,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31155,7 +31159,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37867,7 +37871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37900,7 +37904,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37953,11 +37957,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -37994,11 +37998,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38033,7 +38037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -38066,7 +38070,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -38099,7 +38103,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -38132,7 +38136,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -38165,7 +38169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38198,7 +38202,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38219,7 +38223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38326,23 +38330,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38379,23 +38383,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -38430,7 +38434,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40650,7 +40654,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40709,7 +40713,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46247,7 +46251,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46280,7 +46284,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46313,7 +46317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46349,12 +46353,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -46389,7 +46393,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46422,7 +46426,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46455,7 +46459,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46488,7 +46492,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46521,7 +46525,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46554,7 +46558,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46587,7 +46591,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46620,7 +46624,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48102,7 +48106,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -48135,7 +48139,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -48168,7 +48172,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -50047,9 +50051,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -50080,9 +50084,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -50113,9 +50117,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -50146,9 +50150,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -50179,9 +50183,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50212,9 +50216,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56960,7 +56964,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56993,7 +56997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -57046,11 +57050,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57087,11 +57091,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57126,7 +57130,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -57159,7 +57163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -57192,7 +57196,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -57225,7 +57229,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57258,7 +57262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57291,7 +57295,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57312,7 +57316,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57419,23 +57423,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57472,23 +57476,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -57523,7 +57527,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59369,9 +59373,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -59520,12 +59524,12 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -64026,7 +64030,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -64085,7 +64089,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -64827,12 +64831,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65615,12 +65619,12 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71286,7 +71290,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71319,7 +71323,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71372,11 +71376,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71413,11 +71417,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71452,7 +71456,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71485,7 +71489,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71518,7 +71522,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71551,7 +71555,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71584,7 +71588,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71617,7 +71621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71638,7 +71642,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71745,23 +71749,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71798,23 +71802,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -71849,7 +71853,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -78298,7 +78302,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78331,7 +78335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78384,11 +78388,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78425,11 +78429,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78464,7 +78468,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78497,7 +78501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78530,7 +78534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78563,7 +78567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78596,7 +78600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78629,7 +78633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78650,7 +78654,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78757,23 +78761,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78810,23 +78814,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -78861,7 +78865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80288,9 +80292,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -81068,7 +81072,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82731,7 +82735,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82764,7 +82768,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82846,7 +82850,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82905,7 +82909,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -85255,7 +85259,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -85288,7 +85292,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -85321,7 +85325,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -91331,7 +91335,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -91364,7 +91368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91417,11 +91421,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91458,11 +91462,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91497,7 +91501,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91530,7 +91534,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91563,7 +91567,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91596,7 +91600,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91629,7 +91633,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91662,7 +91666,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91683,7 +91687,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91790,23 +91794,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91843,23 +91847,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -91894,7 +91898,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl)) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10290,7 +10290,7 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -10558,7 +10558,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -12962,7 +12962,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -13964,7 +13964,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -16997,7 +16997,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -17840,7 +17840,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18343,7 +18343,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18359,7 +18359,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -18929,7 +18929,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -18945,7 +18945,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -19924,7 +19924,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -20373,7 +20373,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -20964,7 +20964,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -20980,7 +20980,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21712,7 +21712,7 @@ get manualApprovals(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -21728,7 +21728,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -22748,7 +22748,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -23196,7 +23196,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -24104,7 +24104,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -24552,7 +24552,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -25459,7 +25459,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -25907,7 +25907,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -26352,7 +26352,7 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -26372,7 +26372,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -26705,7 +26705,7 @@ endpoints?: (URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -27523,7 +27523,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -27539,7 +27539,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: ("eddsa-jcs-2022")[] = [];
@@ -28490,7 +28490,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -28506,7 +28506,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -29370,7 +29370,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -29386,7 +29386,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     
@@ -30205,7 +30205,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -30221,7 +30221,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -31077,7 +31077,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -31570,7 +31570,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -31910,7 +31910,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -32245,7 +32245,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -37792,7 +37792,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -39255,7 +39255,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -39602,7 +39602,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -40599,7 +40599,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -41240,7 +41240,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -41669,7 +41669,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -42003,7 +42003,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -42343,7 +42343,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -46166,7 +46166,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -48047,7 +48047,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -48542,7 +48542,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -48876,7 +48876,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -49208,7 +49208,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -50002,7 +50002,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -50018,7 +50018,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -50667,7 +50667,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -51002,7 +51002,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -51338,7 +51338,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -56885,7 +56885,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -59316,7 +59316,7 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -59340,7 +59340,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -59999,7 +59999,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60336,7 +60336,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -60671,7 +60671,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61009,7 +61009,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61343,7 +61343,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -61677,7 +61677,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62011,7 +62011,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62343,7 +62343,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62641,7 +62641,7 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -62976,7 +62976,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -63975,7 +63975,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -64773,7 +64773,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -65561,7 +65561,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -71211,7 +71211,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -72676,7 +72676,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -78223,7 +78223,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -80144,7 +80144,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -81017,7 +81017,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -82680,7 +82680,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -83364,7 +83364,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -83698,7 +83698,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -85204,7 +85204,7 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -85709,7 +85709,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -91256,7 +91256,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -92930,7 +92930,7 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -92946,7 +92946,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -93362,7 +93362,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -93696,7 +93696,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94246,7 +94246,7 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -94681,7 +94681,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95020,7 +95020,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95357,7 +95357,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -95694,7 +95694,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   
@@ -96027,7 +96027,7 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -28,6 +28,8 @@ import {
 } from "@fedify/vocab-runtime/temporal";
 
 
+import * as _ppM0 from "./preprocessors.ts";
+
 /** Describes an object of any kind. The Object type serves as the base type for
  * most of the other kinds of objects defined in the Activity Vocabulary,
  * including other Core types such as {@link Activity},
@@ -3670,7 +3672,6 @@ get names(): ((string | LanguageString))[] {
         for (const _pp_obj of _expanded) {
       
           {
-            const _ppM0 = await import("./preprocessors.ts");
             const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
               documentLoader,
               contextLoader,
@@ -4004,7 +4005,6 @@ get names(): ((string | LanguageString))[] {
         for (const _pp_obj of _expanded) {
       
           {
-            const _ppM0 = await import("./preprocessors.ts");
             const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
               documentLoader,
               contextLoader,
@@ -10602,7 +10602,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10783,12 +10783,11 @@ get urls(): ((URL | Link))[] {
         let _handled: Image | undefined;
       
         if (_handled === undefined) {
-          const _ppM0 = await import("./preprocessors.ts");
           const _result = await _ppM0["normalizeLinkToImage"](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10814,7 +10813,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -10839,12 +10838,11 @@ get urls(): ((URL | Link))[] {
         let _handled: Image | undefined;
       
         if (_handled === undefined) {
-          const _ppM0 = await import("./preprocessors.ts");
           const _result = await _ppM0["normalizeLinkToImage"](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+            baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -10870,7 +10868,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11054,7 +11052,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11087,7 +11085,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11120,7 +11118,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11153,7 +11151,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11340,7 +11338,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11373,7 +11371,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11406,7 +11404,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11439,7 +11437,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -11514,7 +11512,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -11547,7 +11545,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -11568,7 +11566,7 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -11600,9 +11598,9 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -11634,7 +11632,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -11667,7 +11665,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -11700,7 +11698,7 @@ get urls(): ((URL | Link))[] {
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13927,7 +13925,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -13986,7 +13984,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -17125,7 +17123,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17158,7 +17156,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17191,7 +17189,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17224,7 +17222,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -17257,7 +17255,7 @@ instruments?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -19859,7 +19857,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -19892,7 +19890,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -20882,7 +20880,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -20903,7 +20901,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -20924,7 +20922,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -20945,7 +20943,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -21641,9 +21639,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -21674,9 +21672,9 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -22679,7 +22677,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -22712,7 +22710,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24031,7 +24029,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -24064,7 +24062,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25382,7 +25380,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25415,7 +25413,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -26273,9 +26271,9 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -27459,7 +27457,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -30136,9 +30134,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -30158,7 +30156,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -30179,7 +30177,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -30200,7 +30198,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -31002,7 +31000,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -31023,7 +31021,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -37701,7 +37699,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -37734,7 +37732,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -37867,7 +37865,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -37900,7 +37898,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -37933,7 +37931,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -37966,7 +37964,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -37999,7 +37997,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -38032,7 +38030,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -38053,7 +38051,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -38264,7 +38262,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -40480,7 +40478,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -40539,7 +40537,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -46053,7 +46051,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -46086,7 +46084,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -46119,7 +46117,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -46195,7 +46193,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -46228,7 +46226,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -46261,7 +46259,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -46294,7 +46292,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -46327,7 +46325,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -46360,7 +46358,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -46393,7 +46391,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -46426,7 +46424,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -47902,7 +47900,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -47935,7 +47933,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -47968,7 +47966,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -49847,9 +49845,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -49880,9 +49878,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -49913,9 +49911,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -49946,9 +49944,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -49979,9 +49977,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -50012,9 +50010,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -56726,7 +56724,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -56759,7 +56757,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -56892,7 +56890,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -56925,7 +56923,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -56958,7 +56956,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -56991,7 +56989,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -57024,7 +57022,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -57057,7 +57055,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -57078,7 +57076,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -57289,7 +57287,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -59133,9 +59131,9 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
+        : URL.canParse(v["@id"]) && (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])));
+          : new URL(v["@id"], (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])));
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -63786,7 +63784,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -63845,7 +63843,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -71008,7 +71006,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -71041,7 +71039,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -71174,7 +71172,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -71207,7 +71205,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -71240,7 +71238,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -71273,7 +71271,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -71306,7 +71304,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -71339,7 +71337,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -71360,7 +71358,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -71571,7 +71569,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -77986,7 +77984,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -78019,7 +78017,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -78152,7 +78150,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -78185,7 +78183,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -78218,7 +78216,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -78251,7 +78249,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -78284,7 +78282,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -78317,7 +78315,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -78338,7 +78336,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -78549,7 +78547,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -80754,7 +80752,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -82409,7 +82407,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -82442,7 +82440,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -82524,7 +82522,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -82583,7 +82581,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -84923,7 +84921,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -84956,7 +84954,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -84989,7 +84987,7 @@ relationships?: (Object | URL)[];}
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -90965,7 +90963,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -90998,7 +90996,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -91131,7 +91129,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -91164,7 +91162,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -91197,7 +91195,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -91230,7 +91228,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -91263,7 +91261,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -91296,7 +91294,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -91317,7 +91315,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -91528,7 +91526,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+      { ...options, baseUrl: (values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"])) }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10717,9 +10717,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -10776,9 +10784,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -10849,9 +10865,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -10910,9 +10934,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11007,9 +11039,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11084,9 +11124,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11147,9 +11195,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11184,9 +11240,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11235,9 +11299,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11286,9 +11358,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11359,9 +11439,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11396,9 +11484,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11433,9 +11529,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11470,9 +11574,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11553,9 +11665,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11681,9 +11801,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11718,9 +11846,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11755,9 +11891,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11792,9 +11936,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -11908,9 +12060,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -12011,9 +12171,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -12048,9 +12216,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -12085,9 +12261,17 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -14334,9 +14518,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -14397,9 +14589,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -17562,9 +17762,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -17635,9 +17843,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -17672,9 +17888,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -17709,9 +17933,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -17746,9 +17978,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -17783,9 +18023,17 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -20427,9 +20675,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -20464,9 +20720,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -23325,9 +23589,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -23362,9 +23634,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -24703,9 +24983,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -24740,9 +25028,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -26080,9 +26376,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -26117,9 +26421,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -28199,9 +28511,17 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -29166,9 +29486,17 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -30080,9 +30408,17 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38672,9 +39008,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38709,9 +39053,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38764,9 +39116,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38813,9 +39173,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38862,9 +39230,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38899,9 +39275,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38936,9 +39320,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -38973,9 +39365,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -39010,9 +39410,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -39047,9 +39455,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -39181,9 +39597,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -39254,9 +39678,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -39327,9 +39759,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -41568,9 +42008,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -41631,9 +42079,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47236,9 +47692,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47273,9 +47737,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47310,9 +47782,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47347,9 +47827,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47398,9 +47886,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47435,9 +47931,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47472,9 +47976,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47509,9 +48021,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47546,9 +48066,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47583,9 +48111,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47620,9 +48156,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -47657,9 +48201,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -49158,9 +49710,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -49195,9 +49755,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -49232,9 +49800,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58175,9 +58751,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58212,9 +58796,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58267,9 +58859,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58316,9 +58916,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58365,9 +58973,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58402,9 +59018,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58439,9 +59063,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58476,9 +59108,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58513,9 +59153,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58550,9 +59198,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58684,9 +59340,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58757,9 +59421,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -58830,9 +59502,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -60850,9 +61530,17 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -65408,9 +66096,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -65471,9 +66167,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -66221,9 +66925,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -67024,9 +67736,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -72777,9 +73497,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -72814,9 +73542,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -72869,9 +73605,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -72918,9 +73662,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -72967,9 +73719,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73004,9 +73764,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73041,9 +73809,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73078,9 +73854,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73115,9 +73899,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73152,9 +73944,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73286,9 +74086,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73359,9 +74167,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -73432,9 +74248,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -79959,9 +80783,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -79996,9 +80828,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80051,9 +80891,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80100,9 +80948,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80149,9 +81005,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80186,9 +81050,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80223,9 +81095,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80260,9 +81140,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80297,9 +81185,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80334,9 +81230,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80468,9 +81372,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80541,9 +81453,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -80614,9 +81534,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -82843,9 +83771,17 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -84529,9 +85465,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -84566,9 +85510,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -84652,9 +85604,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -84715,9 +85675,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -87098,9 +88066,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -87135,9 +88111,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -87172,9 +88156,17 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93260,9 +94252,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93297,9 +94297,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93352,9 +94360,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93401,9 +94417,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93450,9 +94474,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93487,9 +94519,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93524,9 +94564,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93561,9 +94609,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93598,9 +94654,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93635,9 +94699,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93769,9 +94841,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93842,9 +94922,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }
@@ -93915,9 +95003,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], (values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl)))
         );
         continue;
       }

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`generateClasses() 1`] = `
-"// deno-lint-ignore-file ban-unused-ignore no-unused-vars prefer-const verbatim-module-syntax
+"// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-unused-vars prefer-const verbatim-module-syntax
 import jsonld from "@fedify/vocab-runtime/jsonld";
 import { getLogger } from "@logtape/logtape";
 import { type Span, SpanStatusCode, type TracerProvider, trace }
@@ -3663,6 +3663,26 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      
+          {
+            const _ppM0 = await import("./preprocessors.ts");
+            const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as Image;
+          }
+        
+        }
+      
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -3977,6 +3997,26 @@ get names(): ((string | LanguageString))[] {
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      
+          {
+            const _ppM0 = await import("./preprocessors.ts");
+            const _result = await _ppM0["normalizeLinkToImage"](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as Image;
+          }
+        
+        }
+      
         try {
           return await Image.fromJsonLd(
             jsonLd,
@@ -10739,6 +10779,29 @@ get urls(): ((URL | Link))[] {
     ) {
       if (v == null) continue;
     
+      {
+        let _handled: Image | undefined;
+      
+        if (_handled === undefined) {
+          const _ppM0 = await import("./preprocessors.ts");
+          const _result = await _ppM0["normalizeLinkToImage"](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as Image;
+          }
+        }
+      
+        if (_handled !== undefined) {
+          _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(_handled);
+          continue;
+        }
+      }
+      
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
@@ -10772,6 +10835,29 @@ get urls(): ((URL | Link))[] {
     ) {
       if (v == null) continue;
     
+      {
+        let _handled: Image | undefined;
+      
+        if (_handled === undefined) {
+          const _ppM0 = await import("./preprocessors.ts");
+          const _result = await _ppM0["normalizeLinkToImage"](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])),
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as Image;
+          }
+        }
+      
+        if (_handled !== undefined) {
+          _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(_handled);
+          continue;
+        }
+      }
+      
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10425,6 +10425,9 @@ get urls(): ((URL | Link))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -13273,6 +13276,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -14282,6 +14288,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -17372,6 +17381,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -18255,6 +18267,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -18764,6 +18779,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -19357,6 +19375,9 @@ unit?: string | null;numericalValue?: Decimal | null;}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -20361,6 +20382,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -20817,6 +20841,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -21415,6 +21442,9 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -22186,6 +22216,9 @@ get manualApprovals(): (URL)[] {
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -23247,6 +23280,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -23702,6 +23738,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -24619,6 +24658,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -25074,6 +25116,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -25990,6 +26035,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -26446,6 +26494,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -26898,6 +26949,9 @@ get endpoints(): (URL)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -27258,6 +27312,9 @@ endpoints?: (URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -28083,6 +28140,9 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -29066,6 +29126,9 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -29977,6 +30040,9 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -30838,6 +30904,9 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -31731,6 +31800,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -32232,6 +32304,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -32572,6 +32647,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -32906,6 +32984,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -38522,6 +38603,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -40081,6 +40165,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -40427,6 +40514,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -41433,6 +41523,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -42082,6 +42175,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -42511,6 +42607,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -42844,6 +42943,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -43184,6 +43286,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -47056,6 +47161,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -49001,6 +49109,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -49508,6 +49619,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -49842,6 +49956,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -50173,6 +50290,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -50975,6 +51095,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -51688,6 +51811,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -52022,6 +52148,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -52358,6 +52487,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -57974,6 +58106,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -60512,6 +60647,9 @@ get names(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -61211,6 +61349,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -61548,6 +61689,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -61882,6 +62026,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -62221,6 +62368,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -62554,6 +62704,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -62889,6 +63042,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -63223,6 +63379,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -63555,6 +63714,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -63852,6 +64014,9 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -64187,6 +64352,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -65195,6 +65363,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -66005,6 +66176,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -66804,6 +66978,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -72531,6 +72708,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -74091,6 +74271,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -79707,6 +79890,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -81724,6 +81910,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -82608,6 +82797,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -84292,6 +84484,9 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -84992,6 +85187,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -85325,6 +85523,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -86852,6 +87053,9 @@ relationships?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -87368,6 +87572,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -92984,6 +93191,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -94761,6 +94971,9 @@ get contents(): ((string | LanguageString))[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -95193,6 +95406,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -95526,6 +95742,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -96077,6 +96296,9 @@ get formerTypes(): ($EntityType)[] {
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -96512,6 +96734,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -96851,6 +97076,9 @@ instruments?: (Object | URL)[];}
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -97187,6 +97415,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
@@ -97525,6 +97756,9 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
@@ -97857,6 +98091,9 @@ instruments?: (Object | URL)[];}
       values =
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
+    }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
     }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -10617,7 +10617,7 @@ get urls(): ((URL | Link))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     
@@ -18471,7 +18471,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -19062,7 +19062,7 @@ unit?: string | null;numericalValue?: Decimal | null;}
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _27fgyFbosTtMAhuepJH8K3ZGURT6: (string)[] = [];
@@ -21116,7 +21116,7 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike: (InteractionRule)[] = [];
@@ -21869,7 +21869,7 @@ get manualApprovals(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval: (URL)[] = [];
@@ -26560,7 +26560,7 @@ get endpoints(): (URL)[] {
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
@@ -27737,7 +27737,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: ("eddsa-jcs-2022")[] = [];
@@ -28711,7 +28711,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     
@@ -29598,7 +29598,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     
@@ -30438,7 +30438,7 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _38VmZKmXJSBy3AvgqNa9GVqbdphy_action: (string)[] = [];
@@ -50393,7 +50393,7 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
@@ -59776,7 +59776,7 @@ get names(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
@@ -93637,7 +93637,7 @@ get contents(): ((string | LanguageString))[] {
   }
   
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -48,6 +48,7 @@ export class Object {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -76,6 +77,10 @@ export class Object {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -205,6 +210,8 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -3784,7 +3791,7 @@ get names(): ((string | LanguageString))[] {
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       
           }
@@ -3886,7 +3893,7 @@ get names(): ((string | LanguageString))[] {
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       
             }
@@ -4131,7 +4138,7 @@ get names(): ((string | LanguageString))[] {
             v = await this.#image_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       
           }
@@ -4233,7 +4240,7 @@ get names(): ((string | LanguageString))[] {
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       
             }
@@ -18148,6 +18155,7 @@ export class PropertyValue {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18176,6 +18184,10 @@ export class PropertyValue {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -18208,6 +18220,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -18749,6 +18763,7 @@ export class Measure {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18777,6 +18792,10 @@ export class Measure {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -18809,6 +18828,8 @@ unit?: string | null;numericalValue?: Decimal | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -20696,6 +20717,7 @@ export class InteractionPolicy {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -20724,6 +20746,10 @@ export class InteractionPolicy {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -20758,6 +20784,8 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -21488,6 +21516,7 @@ export class InteractionRule {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -21516,6 +21545,10 @@ export class InteractionRule {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -21550,6 +21583,8 @@ manualApprovals?: (URL)[];}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -26283,6 +26318,7 @@ export class DidService {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -26311,6 +26347,10 @@ export class DidService {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -26343,6 +26383,8 @@ endpoints?: (URL)[];}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -27087,6 +27129,7 @@ export class DataIntegrityProof {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -27115,6 +27158,10 @@ export class DataIntegrityProof {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -27152,6 +27199,8 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -28126,6 +28175,7 @@ export class CryptographicKey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -28154,6 +28204,10 @@ export class CryptographicKey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -28188,6 +28242,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -29019,6 +29075,7 @@ export class Multikey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -29047,6 +29104,10 @@ export class Multikey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -29081,6 +29142,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -29917,6 +29980,7 @@ export class Intent {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -29945,6 +30009,10 @@ export class Intent {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -29980,6 +30048,8 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -49828,6 +49898,7 @@ export class Endpoints {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -49856,6 +49927,10 @@ export class Endpoints {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -49892,6 +49967,8 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -58785,6 +58862,7 @@ export class Link {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -58813,6 +58891,10 @@ export class Link {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -58855,6 +58937,8 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];
@@ -93516,6 +93600,7 @@ export class Source {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -93544,6 +93629,10 @@ export class Source {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     
     /**
@@ -93577,6 +93666,8 @@ contents?: ((string | LanguageString))[];mediaType?: string | null;}
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -2346,8 +2346,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#attachment_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -2606,8 +2611,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#attribution_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -2708,8 +2718,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#attribution_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -2931,8 +2946,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#audience_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -3032,8 +3052,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#audience_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3299,8 +3324,13 @@ get contents(): ((string | LanguageString))[] {
       
               v = await this.#context_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3573,8 +3603,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#generator_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -3818,8 +3853,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#icon_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -3920,8 +3960,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#icon_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4165,8 +4210,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#image_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4267,8 +4317,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#image_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4499,8 +4554,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#replyTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4600,8 +4660,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#replyTarget_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -4832,8 +4897,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#location_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -4933,8 +5003,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#location_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -5164,8 +5239,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#preview_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5264,8 +5344,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#preview_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -5500,8 +5585,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#replies_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5728,8 +5818,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#shares_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -5956,8 +6051,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#likes_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6178,8 +6278,13 @@ get names(): ((string | LanguageString))[] {
       
             v = await this.#emojiReactions_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6452,8 +6557,13 @@ get summaries(): ((string | LanguageString))[] {
       
               v = await this.#tag_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -6709,8 +6819,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#to_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -6810,8 +6925,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#to_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7033,8 +7153,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#bto_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7134,8 +7259,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#bto_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7357,8 +7487,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#cc_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7458,8 +7593,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#cc_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -7681,8 +7821,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#bcc_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -7782,8 +7927,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#bcc_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -8068,8 +8218,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#proof_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8168,8 +8323,13 @@ get urls(): ((URL | Link))[] {
       
               v = await this.#proof_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -8430,8 +8590,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#likeAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8652,8 +8817,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#replyAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -8874,8 +9044,13 @@ get urls(): ((URL | Link))[] {
       
             v = await this.#announceAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -10717,17 +10892,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10737,28 +10922,43 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("http://schema.org#PropertyValue") ? await PropertyValue.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10784,17 +10984,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10803,43 +11013,68 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -10865,28 +11100,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
@@ -10934,17 +11184,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -10954,20 +11214,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11039,17 +11309,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11059,20 +11339,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11103,11 +11393,16 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)),
+            baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })(),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11124,28 +11419,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
@@ -11174,11 +11484,16 @@ get urls(): ((URL | Link))[] {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
-            baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)),
+            baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })(),
           });
           if (_result instanceof Error) throw _result;
           if (_result !== undefined) {
@@ -11195,28 +11510,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Image.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
@@ -11240,17 +11570,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11260,20 +11600,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11299,17 +11649,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11319,20 +11679,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11358,17 +11728,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11378,20 +11758,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11439,28 +11829,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _7UpwM3JWcXhADcscukEehBorf6k_replies.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
@@ -11484,28 +11889,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
@@ -11529,28 +11949,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
@@ -11574,28 +12009,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
@@ -11665,17 +12115,27 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -11685,20 +12145,30 @@ get urls(): ((URL | Link))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11757,25 +12227,40 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) : typeof v === "object" && "@type" in v
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -11801,28 +12286,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
@@ -11846,28 +12346,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
@@ -11891,28 +12406,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
@@ -11936,28 +12466,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
@@ -12032,11 +12577,16 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await Source.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
@@ -12060,28 +12610,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DataIntegrityProof.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
@@ -12102,11 +12667,16 @@ get urls(): ((URL | Link))[] {
     
       const decoded = await InteractionPolicy.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MHQfh2N74MMmDLDqYWFo7TxYQK2_interactionPolicy.push(decoded);
@@ -12138,17 +12708,27 @@ get urls(): ((URL | Link))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _23YiVs2miQcEiUdn4u8SvjQKWYim_approvedBy.push(decoded);
     }
@@ -12171,28 +12751,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await LikeAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3fCeb5aXaDDd4fvkQ96BLWifBUBa_likeAuthorization.push(decoded);
@@ -12216,28 +12811,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await ReplyAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _YA4wdUW7rYztAQ6SjhMnJCmcmtP_replyAuthorization.push(decoded);
@@ -12261,28 +12871,43 @@ get urls(): ((URL | Link))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await AnnounceAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _446xEaDBs3Fz6MyzP3PSBaLupkbJ_announceAuthorization.push(decoded);
@@ -13903,8 +14528,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -14148,8 +14778,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -14518,28 +15153,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -14589,28 +15239,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -15559,8 +16224,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#actor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -15661,8 +16331,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#actor_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -15885,8 +16560,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#object_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -15987,8 +16667,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#object_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16214,8 +16899,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#target_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16319,8 +17009,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#target_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16543,8 +17238,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#result_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16645,8 +17345,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#result_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -16870,8 +17575,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#origin_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -16973,8 +17683,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#origin_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -17196,8 +17911,13 @@ instruments?: (Object | URL)[];}
       
             v = await this.#instrument_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -17297,8 +18017,13 @@ instruments?: (Object | URL)[];}
       
               v = await this.#instrument_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -17762,17 +18487,27 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -17781,43 +18516,68 @@ instruments?: (Object | URL)[];}
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -17843,28 +18603,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -17888,28 +18663,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
@@ -17933,28 +18723,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
@@ -17978,28 +18783,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
@@ -18023,28 +18843,43 @@ instruments?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
@@ -20129,8 +20964,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -20350,8 +21190,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -20675,28 +21520,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -20720,28 +21580,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -21744,11 +22619,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3JkwVLb3BNCwCWdsb5RftGAg8vyT_canLike.push(decoded);
@@ -21769,11 +22649,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2UBgLRi5p3DRGGvWyB227i4Qjhzd_canReply.push(decoded);
@@ -21794,11 +22679,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _fu5nmoAj528fBQfnxhY9Daok3Vi_canAnnounce.push(decoded);
@@ -21819,11 +22709,16 @@ canLike?: InteractionRule | null;canReply?: InteractionRule | null;canAnnounce?:
     
       const decoded = await InteractionRule.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _LE3zBTVacTZw2LSyLt4wVUkXeUy_canQuote.push(decoded);
@@ -22529,17 +23424,27 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _2rFyCF14HoyNjitj9PmCzek5iSsg_automaticApproval.push(decoded);
     }
@@ -22570,17 +23475,27 @@ get manualApprovals(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _sxj8y5XMMMBWUnRYFw85MKedCMj_manualApproval.push(decoded);
     }
@@ -23043,8 +23958,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -23264,8 +24184,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -23589,28 +24514,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -23634,28 +24574,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -24437,8 +25392,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -24658,8 +25618,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -24983,28 +25948,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -25028,28 +26008,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -25830,8 +26825,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactingObject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -26051,8 +27051,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#interactionTarget_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -26376,28 +27381,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2114kRKbujWhxEUghdkRYYKbXTGi_interactingObject.push(decoded);
@@ -26421,28 +27441,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2wHyG75YnN15CDMaFk3VNjByu4aL_interactionTarget.push(decoded);
@@ -27313,17 +28348,27 @@ get endpoints(): (URL)[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
     }
@@ -28511,28 +29556,43 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
@@ -29168,8 +30228,13 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       
             v = await this.#owner_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -29486,17 +30551,27 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -29505,43 +30580,68 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -30083,8 +31183,13 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       
             v = await this.#controller_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -30408,17 +31513,27 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -30427,43 +31542,68 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -31307,17 +32447,27 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _BBAeMUUQDwBQn6cvu3P2Csd6b6h_resourceConformsTo.push(decoded);
     }
@@ -31337,11 +32487,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2dLfqTbbRiggEcMQWbHpxkQrtmrc_resourceQuantity.push(decoded);
@@ -31362,11 +32517,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _YmNSnuih3Zk4VdR5JPVnQYroLAh_availableQuantity.push(decoded);
@@ -31387,11 +32547,16 @@ action?: string | null;resourceConformsTo?: URL | null;resourceQuantity?: Measur
     
       const decoded = await Measure.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3XueAFds2NBrqNpnV8b7aC8hV72S_minimumQuantity.push(decoded);
@@ -32196,11 +33361,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _sS5LvXX8cn4c3x6ux836AwYbTyJ_publishes.push(decoded);
@@ -32221,11 +33391,16 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
     
       const decoded = await Intent.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _Z4ntJgFwR9BaNTbFvkRTGNEwUwy_reciprocal.push(decoded);
@@ -34603,8 +35778,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -34702,8 +35882,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -34927,8 +36112,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35030,8 +36220,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -35292,8 +36487,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35531,8 +36731,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35756,8 +36961,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -35984,8 +37194,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36210,8 +37425,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36434,8 +37654,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36658,8 +37883,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -36880,8 +38110,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -37212,8 +38447,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37472,8 +38712,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37575,8 +38820,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -37800,8 +39050,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -37903,8 +39158,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -39008,28 +40268,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -39053,28 +40328,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -39116,17 +40406,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39135,19 +40435,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -39173,17 +40483,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39192,19 +40512,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -39230,28 +40560,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -39275,28 +40620,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -39320,28 +40680,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -39365,28 +40740,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -39410,28 +40800,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -39455,28 +40860,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -39497,11 +40917,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -39597,17 +41022,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39616,43 +41051,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -39678,17 +41138,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -39697,43 +41167,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -39759,28 +41254,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -41393,8 +42903,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -41638,8 +43153,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -42008,28 +43528,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -42079,28 +43614,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -44504,8 +46054,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#current_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -44726,8 +46281,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#first_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -44948,8 +46508,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#last_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45180,8 +46745,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -45402,8 +46972,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#likesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45623,8 +47198,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#sharesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -45844,8 +47424,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#repliesOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46065,8 +47650,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#inboxOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46286,8 +47876,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#outboxOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46507,8 +48102,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#followersOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46728,8 +48328,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#followingOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -46949,8 +48554,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#likedOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -47692,28 +49302,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
@@ -47737,28 +49362,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
@@ -47782,28 +49422,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
@@ -47827,17 +49482,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -47847,20 +49512,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -47886,28 +49561,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
@@ -47931,28 +49621,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
@@ -47976,28 +49681,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
@@ -48021,28 +49741,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
@@ -48066,28 +49801,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
@@ -48111,28 +49861,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
@@ -48156,28 +49921,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
@@ -48201,28 +49981,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
@@ -48905,8 +50700,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#partOf_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49125,8 +50925,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#next_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49346,8 +51151,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#prev_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -49710,28 +51520,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
@@ -49755,28 +51580,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
@@ -49800,28 +51640,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
@@ -51719,17 +53574,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
     }
@@ -51760,17 +53625,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
     }
@@ -51801,17 +53676,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
     }
@@ -51842,17 +53727,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
     }
@@ -51883,17 +53778,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
     }
@@ -51924,17 +53829,27 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
     }
@@ -54346,8 +56261,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -54445,8 +56365,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -54670,8 +56595,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -54773,8 +56703,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -55035,8 +56970,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55274,8 +57214,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55499,8 +57444,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55727,8 +57677,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -55953,8 +57908,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56177,8 +58137,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56401,8 +58366,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -56623,8 +58593,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -56955,8 +58930,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57215,8 +59195,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57318,8 +59303,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -57543,8 +59533,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -57646,8 +59641,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -58751,28 +60751,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -58796,28 +60811,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -58859,17 +60889,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -58878,19 +60918,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -58916,17 +60966,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -58935,19 +60995,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -58973,28 +61043,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -59018,28 +61103,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -59063,28 +61163,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -59108,28 +61223,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -59153,28 +61283,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -59198,28 +61343,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -59240,11 +61400,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -59340,17 +61505,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -59359,43 +61534,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -59421,17 +61621,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -59440,43 +61650,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -59502,28 +61737,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -60870,8 +63120,13 @@ get names(): ((string | LanguageString))[] {
       
               v = await this.#preview_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -61383,17 +63638,27 @@ get names(): ((string | LanguageString))[] {
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)));
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })());
       if (typeof decoded === "undefined") continue;
       _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
     }
@@ -61530,17 +63795,27 @@ get names(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -61550,20 +63825,30 @@ get names(): ((string | LanguageString))[] {
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -65481,8 +67766,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -65726,8 +68016,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -66096,28 +68391,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -66167,28 +68477,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -66633,8 +68958,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -66925,17 +69255,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -66945,20 +69285,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -67395,8 +69745,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
               v = await this.#item_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -67736,17 +70091,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -67756,20 +70121,30 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://gotosocial.org/ns#AnnounceAuthorization","https://gotosocial.org/ns#LikeApproval","https://gotosocial.org/ns#ReplyAuthorization","https://w3id.org/fep/044f#QuoteAuthorization","https://w3id.org/valueflows/ont/vf#Proposal","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://gotosocial.org/ns#AnnounceRequest","https://gotosocial.org/ns#LikeRequest","https://gotosocial.org/ns#ReplyRequest","https://w3id.org/fep/044f#QuoteRequest","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -69092,8 +71467,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -69191,8 +71571,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -69416,8 +71801,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -69519,8 +71909,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -69781,8 +72176,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70020,8 +72420,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70245,8 +72650,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70473,8 +72883,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70699,8 +73114,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -70923,8 +73343,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71147,8 +73572,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71369,8 +73799,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -71701,8 +74136,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -71961,8 +74401,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -72064,8 +74509,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -72289,8 +74739,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -72392,8 +74847,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -73497,28 +75957,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -73542,28 +76017,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -73605,17 +76095,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -73624,19 +76124,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -73662,17 +76172,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -73681,19 +76201,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -73719,28 +76249,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -73764,28 +76309,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -73809,28 +76369,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -73854,28 +76429,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -73899,28 +76489,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -73944,28 +76549,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -73986,11 +76606,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -74086,17 +76711,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -74105,43 +76740,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -74167,17 +76827,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -74186,43 +76856,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -74248,28 +76943,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -76378,8 +79088,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -76477,8 +79192,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -76702,8 +79422,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -76805,8 +79530,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -77067,8 +79797,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77306,8 +80041,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77531,8 +80271,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77759,8 +80504,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -77985,8 +80735,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78209,8 +80964,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78433,8 +81193,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -78655,8 +81420,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -78987,8 +81757,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79247,8 +82022,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79350,8 +82130,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -79575,8 +82360,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -79678,8 +82468,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -80783,28 +83578,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -80828,28 +83638,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -80891,17 +83716,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -80910,19 +83745,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -80948,17 +83793,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -80967,19 +83822,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -81005,28 +83870,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -81050,28 +83930,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -81095,28 +83990,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -81140,28 +84050,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -81185,28 +84110,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -81230,28 +84170,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -81272,11 +84227,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -81372,17 +84332,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -81391,43 +84361,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -81453,17 +84448,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -81472,43 +84477,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -81534,28 +84564,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
@@ -82985,17 +86030,27 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
               : ""
           )
         )
-        : URL.canParse(v["@id"]) && (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))
+        : URL.canParse(v["@id"]) && (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) : undefined
+          : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
@@ -83481,8 +86536,13 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       
             v = await this.#describes_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -83771,28 +86831,43 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
@@ -84388,8 +87463,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
               v = await this.#exclusiveOption_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -84613,8 +87693,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
               v = await this.#inclusiveOption_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -84867,8 +87952,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
             v = await this.#quote_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -85112,8 +88202,13 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       
             v = await this.#quoteAuthorization_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -85465,28 +88560,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
@@ -85510,28 +88620,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
@@ -85604,28 +88729,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3obhVLFML2Fh2Qsbg3BM2dec8S9e_quote.push(decoded);
@@ -85675,28 +88815,43 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await QuoteAuthorization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _ZKAEiJeuEvjeYkC4pG58D5vAJ4m_quoteAuthorization.push(decoded);
@@ -87058,8 +90213,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#subject_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87279,8 +90439,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#object_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87379,8 +90544,13 @@ relationships?: (Object | URL)[];}
       
               v = await this.#object_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -87603,8 +90773,13 @@ relationships?: (Object | URL)[];}
       
             v = await this.#relationship_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -87705,8 +90880,13 @@ relationships?: (Object | URL)[];}
       
               v = await this.#relationship_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -88066,28 +91246,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
@@ -88111,28 +91306,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
@@ -88156,28 +91366,43 @@ relationships?: (Object | URL)[];}
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Object.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
@@ -89847,8 +93072,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#publicKey_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -89946,8 +93176,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#publicKey_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -90171,8 +93406,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#assertionMethod_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90274,8 +93514,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#assertionMethod_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -90536,8 +93781,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#inbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -90775,8 +94025,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#outbox_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91000,8 +94255,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#following_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91228,8 +94488,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#followers_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91454,8 +94719,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#liked_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91678,8 +94948,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featured_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -91902,8 +95177,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#featuredTags_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92124,8 +95404,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#stream_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -92456,8 +95741,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#successor_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92716,8 +96006,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#alias_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -92819,8 +96114,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#alias_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -93044,8 +96344,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
             v = await this.#service_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
             });
       
           }
@@ -93147,8 +96452,13 @@ get preferredUsernames(): ((string | LanguageString))[] {
       
               v = await this.#service_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined),
               });
       
             }
@@ -94252,28 +97562,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await CryptographicKey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
@@ -94297,28 +97622,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Multikey.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
@@ -94360,17 +97700,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94379,19 +97729,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -94417,17 +97777,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94436,19 +97806,29 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollectionPage") ? await OrderedCollectionPage.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -94474,28 +97854,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
@@ -94519,28 +97914,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
@@ -94564,28 +97974,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
@@ -94609,28 +98034,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
@@ -94654,28 +98094,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
@@ -94699,28 +98154,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await Collection.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
@@ -94741,11 +98211,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
     
       const decoded = await Endpoints.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
@@ -94841,17 +98316,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94860,43 +98345,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -94922,17 +98432,27 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
@@ -94941,43 +98461,68 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Group") ? await Group.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Organization") ? await Organization.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Person") ? await Person.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Service") ? await Service.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     ) : undefined
       ;
       if (typeof decoded === "undefined") continue;
@@ -95003,28 +98548,43 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(
-          !URL.canParse(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"], (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)))
+            : new URL(v["@id"], (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })())
         );
         continue;
       }
       
       const decoded = await DidService.fromJsonLd(
       v,
-      { ...options, baseUrl: (values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl)) }
+      { ...options, baseUrl: (() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })() }
     );
       if (typeof decoded === "undefined") continue;
       _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -37,6 +37,7 @@ export function sortTopologically(types: Record<string, TypeSchema>): string[] {
 async function* generateClass(
   typeUri: string,
   types: Record<string, TypeSchema>,
+  moduleVarNames: ReadonlyMap<string, string>,
 ): AsyncIterable<string> {
   const type = types[typeUri];
   yield `/** ${type.description.replaceAll("\n", "\n * ")}\n */\n`;
@@ -99,9 +100,13 @@ async function* generateClass(
   for await (const code of generateFields(typeUri, types)) yield code;
   for await (const code of generateConstructor(typeUri, types)) yield code;
   for await (const code of generateCloner(typeUri, types)) yield code;
-  for await (const code of generateProperties(typeUri, types)) yield code;
+  for await (const code of generateProperties(typeUri, types, moduleVarNames)) {
+    yield code;
+  }
   for await (const code of generateEncoder(typeUri, types)) yield code;
-  for await (const code of generateDecoder(typeUri, types)) yield code;
+  for await (const code of generateDecoder(typeUri, types, moduleVarNames)) {
+    yield code;
+  }
   for await (const code of generateInspector(typeUri, types)) yield code;
   yield "}\n\n";
   for await (const code of generateInspectorPostClass(typeUri, types)) {
@@ -197,9 +202,27 @@ export async function* generateClasses(
     isTemporalInstant,
 } from "@fedify/vocab-runtime/temporal";\n`;
   yield "\n\n";
+  const moduleVarNames = new Map<string, string>();
   const sorted = sortTopologically(types);
   for (const typeUri of sorted) {
-    for await (const code of generateClass(typeUri, types)) yield code;
+    for (const property of types[typeUri].properties) {
+      if (property.preprocessors == null) continue;
+      for (const pp of property.preprocessors) {
+        if (!moduleVarNames.has(pp.module)) {
+          const name = `_ppM${moduleVarNames.size}`;
+          moduleVarNames.set(pp.module, name);
+        }
+      }
+    }
+  }
+  for (const [modulePath, varName] of moduleVarNames) {
+    yield `import * as ${varName} from ${JSON.stringify(modulePath)};\n`;
+  }
+  if (moduleVarNames.size > 0) yield "\n";
+  for (const typeUri of sorted) {
+    for await (const code of generateClass(typeUri, types, moduleVarNames)) {
+      yield code;
+    }
   }
   for (const code of generateEntityTypeHelpers(sorted, types)) yield code;
 }

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -184,7 +184,7 @@ export async function* generateClasses(
     "parseDecimal",
     "type RemoteDocument",
   ];
-  yield "// deno-lint-ignore-file ban-unused-ignore no-unused-vars prefer-const verbatim-module-syntax\n";
+  yield "// deno-lint-ignore-file ban-unused-ignore no-explicit-any no-unused-vars prefer-const verbatim-module-syntax\n";
   yield 'import jsonld from "@fedify/vocab-runtime/jsonld";\n';
   yield 'import { getLogger } from "@logtape/logtape";\n';
   yield `import { type Span, SpanStatusCode, type TracerProvider, trace }

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -58,6 +58,7 @@ async function* generateClass(
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    readonly #_baseUrl?: URL;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -86,6 +87,10 @@ async function* generateClass(
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _baseUrl(): URL | undefined {
+      return this.#_baseUrl;
     }
     `;
   }

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,13 +404,14 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    const _resolvedUrl =
+      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
+        ? new URL(values["@id"], options.baseUrl)
+        : undefined;
+    if (options.baseUrl == null && _resolvedUrl != null) {
+      options = { ...options, baseUrl: _resolvedUrl };
     }
-    const _baseUrl =
-      values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl);
+    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   `;
   const subtypes = getSubtypes(typeUri, types, true);
   yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -475,11 +475,16 @@ export async function* generateDecoder(
     ) {
       if (v == null) continue;
     `;
+    const propertyBaseUrl = `(values["@id"] == null ||
+          values["@id"].startsWith("_:") ||
+          !URL.canParse(values["@id"] as string, options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"] as string, options.baseUrl))`;
     yield* generatePreprocessorBlock(
       property,
       getTypeNames(property.range, types),
       variable,
-      `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+      propertyBaseUrl,
       moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
@@ -503,7 +508,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+          propertyBaseUrl,
         )
       };
       if (typeof decoded === "undefined") continue;
@@ -517,7 +522,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+        propertyBaseUrl,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -478,11 +478,16 @@ export async function* generateDecoder(
     ) {
       if (v == null) continue;
     `;
-    const propertyBaseUrl = `(values["@id"] == null ||
-          values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"], options.baseUrl)
-        ? options.baseUrl
-        : new URL(values["@id"], options.baseUrl))`;
+    const propertyBaseUrl = `(() => {
+          if (values["@id"] == null || values["@id"].startsWith("_:") ||
+              !URL.canParse(values["@id"], options.baseUrl)) {
+            return options.baseUrl;
+          }
+          const id = new URL(values["@id"], options.baseUrl);
+          return id.protocol === "http:" || id.protocol === "https:"
+            ? id
+            : options.baseUrl;
+        })()`;
     yield* generatePreprocessorBlock(
       property,
       getTypeNames(property.range, types),

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -1,6 +1,6 @@
 import metadata from "../deno.json" with { type: "json" };
 import { generateField, getFieldName } from "./field.ts";
-import type { TypeSchema } from "./schema.ts";
+import type { PropertyPreprocessorSchema, TypeSchema } from "./schema.ts";
 import { isNonFunctionalProperty } from "./schema.ts";
 import {
   areAllScalarTypes,
@@ -10,8 +10,53 @@ import {
   getDecoders,
   getEncoders,
   getSubtypes,
+  getTypeNames,
   isCompactableType,
 } from "./type.ts";
+
+function* generatePreprocessorBlock(
+  property: { preprocessors?: PropertyPreprocessorSchema[] },
+  rangeTypeName: string,
+  variable: string,
+  baseUrlExpr: string,
+): Iterable<string> {
+  if (property.preprocessors == null || property.preprocessors.length === 0) {
+    return;
+  }
+  yield `
+      {
+        let _handled: ${rangeTypeName} | undefined;
+      `;
+  let moduleIndex = 0;
+  for (const pp of property.preprocessors) {
+    yield `
+        {
+          const _ppM${moduleIndex} = await import(${JSON.stringify(pp.module)});
+          const _result = await _ppM${moduleIndex}[${
+      JSON.stringify(pp.function)
+    }](v, {
+            documentLoader: options.documentLoader,
+            contextLoader: options.contextLoader,
+            tracerProvider: options.tracerProvider,
+            baseUrl: ${baseUrlExpr},
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) {
+            _handled = _result as ${rangeTypeName};
+          }
+        }
+        if (_handled !== undefined) break;
+      `;
+    moduleIndex++;
+  }
+  yield `
+        if (_handled !== undefined) {
+          ${variable}.push(_handled);
+          continue;
+        }
+      }
+      `;
+}
 
 export async function* generateEncoder(
   typeUri: string,
@@ -426,6 +471,12 @@ export async function* generateDecoder(
     ) {
       if (v == null) continue;
     `;
+    yield* generatePreprocessorBlock(
+      property,
+      getTypeNames(property.range, types),
+      variable,
+      `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+    );
     if (!areAllScalarTypes(property.range, types)) {
       yield `
       if (typeof v === "object" && "@id" in v && !("@type" in v)

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -432,7 +432,7 @@ export async function* generateDecoder(
   if (type.extends == null) {
     yield `
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     `;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -30,7 +30,13 @@ function* generatePreprocessorBlock(
       `;
   for (const pp of property.preprocessors) {
     const varName = moduleVarNames.get(pp.module);
-    if (varName == null) continue;
+    if (varName == null) {
+      throw new Error(
+        `Preprocessor module "${pp.module}" is not registered ` +
+          `in the generated imports. Ensure all preprocessor ` +
+          `modules used in property schemas are available.`,
+      );
+    }
     yield `
         if (_handled === undefined) {
           const _result = await ${varName}[${JSON.stringify(pp.function)}](v, {
@@ -401,6 +407,10 @@ export async function* generateDecoder(
     if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
+    const _baseUrl =
+      values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl)
+        ? options.baseUrl
+        : new URL(values["@id"], options.baseUrl);
   `;
   const subtypes = getSubtypes(typeUri, types, true);
   yield `
@@ -473,7 +483,7 @@ export async function* generateDecoder(
       property,
       getTypeNames(property.range, types),
       variable,
-      `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
+      `_baseUrl`,
       moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
@@ -497,7 +507,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
+          `_baseUrl`,
         )
       };
       if (typeof decoded === "undefined") continue;
@@ -511,7 +521,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
+        `_baseUrl`,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,6 +404,9 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
+    if (values["@id"] != null && !values["@id"].startsWith("_:") && !URL.canParse(values["@id"], options.baseUrl)) {
+      throw new TypeError("Invalid @id: " + values["@id"]);
+    }
     if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -478,16 +478,7 @@ export async function* generateDecoder(
     ) {
       if (v == null) continue;
     `;
-    const propertyBaseUrl = `(() => {
-          if (values["@id"] == null || values["@id"].startsWith("_:") ||
-              !URL.canParse(values["@id"], options.baseUrl)) {
-            return options.baseUrl;
-          }
-          const id = new URL(values["@id"], options.baseUrl);
-          return id.protocol === "http:" || id.protocol === "https:"
-            ? id
-            : options.baseUrl;
-        })()`;
+    const propertyBaseUrl = "options.baseUrl";
     yield* generatePreprocessorBlock(
       property,
       getTypeNames(property.range, types),

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,7 +404,7 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
+    if (options.baseUrl == null && values["@id"] != null) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   `;
@@ -479,7 +479,7 @@ export async function* generateDecoder(
       property,
       getTypeNames(property.range, types),
       variable,
-      `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
+      `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
       moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
@@ -503,7 +503,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
+          `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
         )
       };
       if (typeof decoded === "undefined") continue;
@@ -517,7 +517,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
+        `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -398,7 +398,7 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   `;
@@ -511,7 +511,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+        `(values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))`,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -495,9 +495,9 @@ export async function* generateDecoder(
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         ${variable}.push(
-          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+          !URL.canParse(v["@id"], ${propertyBaseUrl}) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
+            : new URL(v["@id"], ${propertyBaseUrl})
         );
         continue;
       }

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,14 +404,9 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    const _resolvedUrl =
-      values["@id"] != null && URL.canParse(values["@id"], options.baseUrl)
-        ? new URL(values["@id"], options.baseUrl)
-        : undefined;
-    if (options.baseUrl == null && _resolvedUrl != null) {
-      options = { ...options, baseUrl: _resolvedUrl };
+    if (options.baseUrl == null && values["@id"] != null) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
-    const _baseUrl = _resolvedUrl ?? options.baseUrl;
   `;
   const subtypes = getSubtypes(typeUri, types, true);
   yield `
@@ -484,7 +479,7 @@ export async function* generateDecoder(
       property,
       getTypeNames(property.range, types),
       variable,
-      `_baseUrl`,
+      `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
       moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
@@ -508,7 +503,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `_baseUrl`,
+          `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
         )
       };
       if (typeof decoded === "undefined") continue;
@@ -522,7 +517,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `_baseUrl`,
+        `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -19,6 +19,7 @@ function* generatePreprocessorBlock(
   rangeTypeName: string,
   variable: string,
   baseUrlExpr: string,
+  moduleVarNames: ReadonlyMap<string, string>,
 ): Iterable<string> {
   if (property.preprocessors == null || property.preprocessors.length === 0) {
     return;
@@ -27,14 +28,12 @@ function* generatePreprocessorBlock(
       {
         let _handled: ${rangeTypeName} | undefined;
       `;
-  let moduleIndex = 0;
   for (const pp of property.preprocessors) {
+    const varName = moduleVarNames.get(pp.module);
+    if (varName == null) continue;
     yield `
         if (_handled === undefined) {
-          const _ppM${moduleIndex} = await import(${JSON.stringify(pp.module)});
-          const _result = await _ppM${moduleIndex}[${
-      JSON.stringify(pp.function)
-    }](v, {
+          const _result = await ${varName}[${JSON.stringify(pp.function)}](v, {
             documentLoader: options.documentLoader,
             contextLoader: options.contextLoader,
             tracerProvider: options.tracerProvider,
@@ -46,7 +45,6 @@ function* generatePreprocessorBlock(
           }
         }
       `;
-    moduleIndex++;
   }
   yield `
         if (_handled !== undefined) {
@@ -315,6 +313,7 @@ export async function* generateEncoder(
 export async function* generateDecoder(
   typeUri: string,
   types: Record<string, TypeSchema>,
+  moduleVarNames: ReadonlyMap<string, string>,
 ): AsyncIterable<string> {
   const type = types[typeUri];
   yield `
@@ -474,7 +473,8 @@ export async function* generateDecoder(
       property,
       getTypeNames(property.range, types),
       variable,
-      `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+      `(values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))`,
+      moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
       yield `
@@ -497,7 +497,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+          `(values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))`,
         )
       };
       if (typeof decoded === "undefined") continue;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -437,7 +437,7 @@ export async function* generateDecoder(
   if (type.extends == null) {
     yield `
     const instance = new this(
-      { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
+      { id: _resolvedUrl },
       options,
     );
     `;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -437,7 +437,7 @@ export async function* generateDecoder(
   if (type.extends == null) {
     yield `
     const instance = new this(
-      { id: _resolvedUrl },
+      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
       options,
     );
     `;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,8 +404,8 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
-      options = { ...options, baseUrl: new URL(values["@id"] as string) };
+    if (options.baseUrl == null && values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"])) {
+      options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   `;
   const subtypes = getSubtypes(typeUri, types, true);
@@ -432,7 +432,7 @@ export async function* generateDecoder(
   if (type.extends == null) {
     yield `
     const instance = new this(
-      { id: "@id" in values && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
+      { id: values["@id"] != null && !values["@id"].startsWith("_:") && URL.canParse(values["@id"], options.baseUrl) ? new URL(values["@id"], options.baseUrl) : undefined },
       options,
     );
     `;
@@ -477,9 +477,9 @@ export async function* generateDecoder(
     `;
     const propertyBaseUrl = `(values["@id"] == null ||
           values["@id"].startsWith("_:") ||
-          !URL.canParse(values["@id"] as string, options.baseUrl)
+          !URL.canParse(values["@id"], options.baseUrl)
         ? options.baseUrl
-        : new URL(values["@id"] as string, options.baseUrl))`;
+        : new URL(values["@id"], options.baseUrl))`;
     yield* generatePreprocessorBlock(
       property,
       getTypeNames(property.range, types),

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,7 +404,7 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:") && URL.canParse(values["@id"] as string)) {
       options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   `;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -473,7 +473,7 @@ export async function* generateDecoder(
       property,
       getTypeNames(property.range, types),
       variable,
-      `(values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))`,
+      `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
       moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
@@ -497,7 +497,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `(values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))`,
+          `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
         )
       };
       if (typeof decoded === "undefined") continue;
@@ -511,7 +511,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `(values["@id"] == null || !URL.canParse(values["@id"]) ? options.baseUrl : new URL(values["@id"]))`,
+        `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,7 +404,7 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
+    if (options.baseUrl == null && values["@id"] != null && URL.canParse(values["@id"])) {
       options = { ...options, baseUrl: new URL(values["@id"]) };
     }
   `;
@@ -432,7 +432,7 @@ export async function* generateDecoder(
   if (type.extends == null) {
     yield `
     const instance = new this(
-      { id: "@id" in values && URL.canParse(values["@id"] as string) ? new URL(values["@id"] as string) : undefined },
+      { id: "@id" in values && URL.canParse(values["@id"] as string, options.baseUrl) ? new URL(values["@id"] as string, options.baseUrl) : undefined },
       options,
     );
     `;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -479,7 +479,7 @@ export async function* generateDecoder(
       property,
       getTypeNames(property.range, types),
       variable,
-      `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+      `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
       moduleVarNames,
     );
     if (!areAllScalarTypes(property.range, types)) {
@@ -503,7 +503,7 @@ export async function* generateDecoder(
           types,
           "v",
           "options",
-          `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+          `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
         )
       };
       if (typeof decoded === "undefined") continue;
@@ -517,7 +517,7 @@ export async function* generateDecoder(
         types,
         "v",
         "options",
-        `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+        `(values["@id"] == null || !URL.canParse(values["@id"], options.baseUrl) ? options.baseUrl : new URL(values["@id"], options.baseUrl))`,
       );
       for (const code of decoders) yield code;
       yield `

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -404,8 +404,8 @@ export async function* generateDecoder(
         // deno-lint-ignore no-explicit-any
         (expanded[0] ?? {}) as (Record<string, any[]> & { "@id"?: string });
     }
-    if (options.baseUrl == null && values["@id"] != null) {
-      options = { ...options, baseUrl: new URL(values["@id"]) };
+    if (options.baseUrl == null && values["@id"] != null && !(values["@id"] as string).startsWith("_:")) {
+      options = { ...options, baseUrl: new URL(values["@id"] as string) };
     }
   `;
   const subtypes = getSubtypes(typeUri, types, true);

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -30,7 +30,7 @@ function* generatePreprocessorBlock(
   let moduleIndex = 0;
   for (const pp of property.preprocessors) {
     yield `
-        {
+        if (_handled === undefined) {
           const _ppM${moduleIndex} = await import(${JSON.stringify(pp.module)});
           const _result = await _ppM${moduleIndex}[${
       JSON.stringify(pp.function)
@@ -45,7 +45,6 @@ function* generatePreprocessorBlock(
             _handled = _result as ${rangeTypeName};
           }
         }
-        if (_handled !== undefined) break;
       `;
     moduleIndex++;
   }

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -490,6 +490,7 @@ export async function* generateDecoder(
       yield `
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
+        if (v["@id"].startsWith("_:")) continue;
         ${variable}.push(
           !URL.canParse(v["@id"], ${propertyBaseUrl}) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))

--- a/packages/vocab-tools/src/constructor.ts
+++ b/packages/vocab-tools/src/constructor.ts
@@ -97,6 +97,8 @@ export async function* generateConstructor(
     this.#documentLoader = options.documentLoader;
     this.#contextLoader = options.contextLoader;
     this.#tracerProvider = options.tracerProvider;
+    const baseUrl = (options as { baseUrl?: URL }).baseUrl;
+    this.#_baseUrl = baseUrl == null ? undefined : new URL(baseUrl.href);
     if ("$warning" in options) {
       this.#warning = options.$warning as unknown as {
         category: string[];

--- a/packages/vocab-tools/src/mod.ts
+++ b/packages/vocab-tools/src/mod.ts
@@ -1,6 +1,7 @@
 export { default as generateVocab } from "./generate.ts";
 export {
   loadSchemaFiles,
+  type PropertyPreprocessorSchema,
   type PropertySchema,
   type TypeSchema,
 } from "./schema.ts";

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -165,6 +165,32 @@ async function* generateProperty(
         this._tracerProvider ?? trace.getTracerProvider();
       const baseUrl = options.baseUrl;
     `;
+    if (
+      property.preprocessors != null &&
+      property.preprocessors.length > 0
+    ) {
+      let moduleIndex = 0;
+      for (const pp of property.preprocessors) {
+        yield `
+        {
+          const _ppM${moduleIndex} = await import(${JSON.stringify(pp.module)});
+          const _result = await _ppM${moduleIndex}[${
+          JSON.stringify(pp.function)
+        }](jsonLd, {
+            documentLoader,
+            contextLoader,
+            tracerProvider,
+            baseUrl,
+          });
+          if (_result instanceof Error) throw _result;
+          if (_result !== undefined) return _result as ${
+          getTypeNames(property.range, types)
+        };
+        }
+        `;
+        moduleIndex++;
+      }
+    }
     for (const range of property.range) {
       if (!(range in types)) continue;
       const rangeType = types[range];

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -26,6 +26,7 @@ async function* generateProperty(
   type: TypeSchema,
   property: PropertySchema,
   types: Record<string, TypeSchema>,
+  moduleVarNames: ReadonlyMap<string, string>,
 ): AsyncIterable<string> {
   const override = emitOverride(type.uri, types, property);
   const doc = `\n/** ${property.description.replaceAll("\n", "\n * ")}\n */\n`;
@@ -176,14 +177,12 @@ async function* generateProperty(
         });
         for (const _pp_obj of _expanded) {
       `;
-      let moduleIndex = 0;
       for (const pp of property.preprocessors) {
+        const varName = moduleVarNames.get(pp.module);
+        if (varName == null) continue;
         yield `
           {
-            const _ppM${moduleIndex} = await import(${
-          JSON.stringify(pp.module)
-        });
-            const _result = await _ppM${moduleIndex}[${
+            const _result = await ${varName}[${
           JSON.stringify(pp.function)
         }](_pp_obj, {
               documentLoader,
@@ -197,7 +196,6 @@ async function* generateProperty(
         };
           }
         `;
-        moduleIndex++;
       }
       yield `
         }
@@ -289,7 +287,11 @@ async function* generateProperty(
             ${JSON.stringify(property.compactName)}];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
-            v = await this.#${property.singularName}_fromJsonLd(doc, options);
+            v = await this.#${property.singularName}_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                undefined,
+            });
           }
         }
         `;
@@ -388,7 +390,11 @@ async function* generateProperty(
               ${JSON.stringify(property.compactName)}];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
-              v = await this.#${property.singularName}_fromJsonLd(obj, options);
+              v = await this.#${property.singularName}_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  undefined,
+              });
             }
           }
         `;
@@ -427,9 +433,10 @@ async function* generateProperty(
 export async function* generateProperties(
   typeUri: string,
   types: Record<string, TypeSchema>,
+  moduleVarNames: ReadonlyMap<string, string>,
 ): AsyncIterable<string> {
   const type = types[typeUri];
   for (const property of type.properties) {
-    yield* generateProperty(type, property, types);
+    yield* generateProperty(type, property, types, moduleVarNames);
   }
 }

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -179,7 +179,13 @@ async function* generateProperty(
       `;
       for (const pp of property.preprocessors) {
         const varName = moduleVarNames.get(pp.module);
-        if (varName == null) continue;
+        if (varName == null) {
+          throw new Error(
+            `Preprocessor module "${pp.module}" is not registered ` +
+              `in the generated imports. Ensure all preprocessor ` +
+              `modules used in property schemas are available.`,
+          );
+        }
         yield `
           {
             const _result = await ${varName}[${

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -287,11 +287,24 @@ async function* generateProperty(
             ${JSON.stringify(property.compactName)}];
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
+      `;
+        if (
+          property.preprocessors != null &&
+          property.preprocessors.length > 0
+        ) {
+          yield `
             v = await this.#${property.singularName}_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 undefined,
             });
+      `;
+        } else {
+          yield `
+            v = await this.#${property.singularName}_fromJsonLd(doc, options);
+      `;
+        }
+        yield `
           }
         }
         `;
@@ -390,11 +403,24 @@ async function* generateProperty(
               ${JSON.stringify(property.compactName)}];
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
+      `;
+        if (
+          property.preprocessors != null &&
+          property.preprocessors.length > 0
+        ) {
+          yield `
               v = await this.#${property.singularName}_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   undefined,
               });
+      `;
+        } else {
+          yield `
+              v = await this.#${property.singularName}_fromJsonLd(obj, options);
+      `;
+        }
+        yield `
             }
           }
         `;

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -171,11 +171,12 @@ async function* generateProperty(
       property.preprocessors.length > 0
     ) {
       yield `
-        const _expanded = await jsonld.expand(jsonLd, {
-          documentLoader: contextLoader,
-          keepFreeFloatingNodes: true,
-        });
-        for (const _pp_obj of _expanded) {
+        if (jsonLd != null && typeof jsonLd === "object") {
+          const _expanded = await jsonld.expand(jsonLd, {
+            documentLoader: contextLoader,
+            keepFreeFloatingNodes: true,
+          });
+          for (const _pp_obj of _expanded) {
       `;
       for (const pp of property.preprocessors) {
         const varName = moduleVarNames.get(pp.module);
@@ -187,23 +188,24 @@ async function* generateProperty(
           );
         }
         yield `
-          {
-            const _result = await ${varName}[${
+            {
+              const _result = await ${varName}[${
           JSON.stringify(pp.function)
         }](_pp_obj, {
-              documentLoader,
-              contextLoader,
-              tracerProvider,
-              baseUrl,
-            });
-            if (_result instanceof Error) throw _result;
-            if (_result !== undefined) return _result as ${
+                documentLoader,
+                contextLoader,
+                tracerProvider,
+                baseUrl,
+              });
+              if (_result instanceof Error) throw _result;
+              if (_result !== undefined) return _result as ${
           getTypeNames(property.range, types)
         };
-          }
+            }
         `;
       }
       yield `
+          }
         }
       `;
     }

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -176,7 +176,7 @@ async function* generateProperty(
           const _ppM${moduleIndex} = await import(${JSON.stringify(pp.module)});
           const _result = await _ppM${moduleIndex}[${
           JSON.stringify(pp.function)
-        }](jsonLd, {
+        }](jsonLd as any, {
             documentLoader,
             contextLoader,
             tracerProvider,

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -309,7 +309,11 @@ async function* generateProperty(
       `;
         } else {
           yield `
-            v = await this.#${property.singularName}_fromJsonLd(doc, options);
+            v = await this.#${property.singularName}_fromJsonLd(doc, {
+              ...options,
+              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                this._baseUrl,
+            });
       `;
         }
         yield `
@@ -425,7 +429,11 @@ async function* generateProperty(
       `;
         } else {
           yield `
-              v = await this.#${property.singularName}_fromJsonLd(obj, options);
+              v = await this.#${property.singularName}_fromJsonLd(obj, {
+                ...options,
+                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
+                  this._baseUrl,
+              });
       `;
         }
         yield `

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -304,7 +304,7 @@ async function* generateProperty(
             v = await this.#${property.singularName}_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                undefined,
+                this._baseUrl,
             });
       `;
         } else {
@@ -420,7 +420,7 @@ async function* generateProperty(
               v = await this.#${property.singularName}_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  undefined,
+                  this._baseUrl,
               });
       `;
         } else {

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -169,27 +169,39 @@ async function* generateProperty(
       property.preprocessors != null &&
       property.preprocessors.length > 0
     ) {
+      yield `
+        const _expanded = await jsonld.expand(jsonLd, {
+          documentLoader: contextLoader,
+          keepFreeFloatingNodes: true,
+        });
+        for (const _pp_obj of _expanded) {
+      `;
       let moduleIndex = 0;
       for (const pp of property.preprocessors) {
         yield `
-        {
-          const _ppM${moduleIndex} = await import(${JSON.stringify(pp.module)});
-          const _result = await _ppM${moduleIndex}[${
+          {
+            const _ppM${moduleIndex} = await import(${
+          JSON.stringify(pp.module)
+        });
+            const _result = await _ppM${moduleIndex}[${
           JSON.stringify(pp.function)
-        }](jsonLd as any, {
-            documentLoader,
-            contextLoader,
-            tracerProvider,
-            baseUrl,
-          });
-          if (_result instanceof Error) throw _result;
-          if (_result !== undefined) return _result as ${
+        }](_pp_obj, {
+              documentLoader,
+              contextLoader,
+              tracerProvider,
+              baseUrl,
+            });
+            if (_result instanceof Error) throw _result;
+            if (_result !== undefined) return _result as ${
           getTypeNames(property.range, types)
         };
-        }
+          }
         `;
         moduleIndex++;
       }
+      yield `
+        }
+      `;
     }
     for (const range of property.range) {
       if (!(range in types)) continue;

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -296,26 +296,13 @@ async function* generateProperty(
           const doc = Array.isArray(prop) ? prop[0] : prop;
           if (doc != null && typeof doc === "object" && "@context" in doc) {
       `;
-        if (
-          property.preprocessors != null &&
-          property.preprocessors.length > 0
-        ) {
-          yield `
+        yield `
             v = await this.#${property.singularName}_fromJsonLd(doc, {
               ...options,
               baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                 this._baseUrl,
             });
       `;
-        } else {
-          yield `
-            v = await this.#${property.singularName}_fromJsonLd(doc, {
-              ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
-            });
-      `;
-        }
         yield `
           }
         }
@@ -416,26 +403,13 @@ async function* generateProperty(
             const obj = Array.isArray(prop) ? prop[i] : prop;
             if (obj != null && typeof obj === "object" && "@context" in obj) {
       `;
-        if (
-          property.preprocessors != null &&
-          property.preprocessors.length > 0
-        ) {
-          yield `
+        yield `
               v = await this.#${property.singularName}_fromJsonLd(obj, {
                 ...options,
                 baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
                   this._baseUrl,
               });
       `;
-        } else {
-          yield `
-              v = await this.#${property.singularName}_fromJsonLd(obj, {
-                ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
-              });
-      `;
-        }
         yield `
             }
           }

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -30,6 +30,13 @@ async function* generateProperty(
 ): AsyncIterable<string> {
   const override = emitOverride(type.uri, types, property);
   const doc = `\n/** ${property.description.replaceAll("\n", "\n * ")}\n */\n`;
+  const cachedPropertyBaseUrl = `(options as { baseUrl?: URL }).baseUrl ??
+                this._baseUrl ??
+                (this.id != null &&
+                    (this.id.protocol === "http:" ||
+                      this.id.protocol === "https:")
+                  ? this.id
+                  : undefined)`;
   if (areAllScalarTypes(property.range, types)) {
     if (hasSingularAccessor(property)) {
       yield doc;
@@ -299,8 +306,7 @@ async function* generateProperty(
         yield `
             v = await this.#${property.singularName}_fromJsonLd(doc, {
               ...options,
-              baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                this._baseUrl,
+              baseUrl: ${cachedPropertyBaseUrl},
             });
       `;
         yield `
@@ -406,8 +412,7 @@ async function* generateProperty(
         yield `
               v = await this.#${property.singularName}_fromJsonLd(obj, {
                 ...options,
-                baseUrl: (options as { baseUrl?: URL }).baseUrl ?? this.id ??
-                  this._baseUrl,
+                baseUrl: ${cachedPropertyBaseUrl},
               });
       `;
         yield `

--- a/packages/vocab-tools/src/schema.ts
+++ b/packages/vocab-tools/src/schema.ts
@@ -130,7 +130,7 @@ export interface PropertySchemaBase {
    * or an `Error` when it recognized the value but failed while converting it.
    *
    * `module` is resolved from the generated vocabulary source file
-   * and imported dynamically at decode time.
+   * and imported statically at the top of the generated file.
    */
   preprocessors?: PropertyPreprocessorSchema[];
 }

--- a/packages/vocab-tools/src/schema.ts
+++ b/packages/vocab-tools/src/schema.ts
@@ -129,7 +129,7 @@ export interface PropertySchemaBase {
    * property's declared range, `undefined` when it did not handle the value,
    * or an `Error` when it recognized the value but failed while converting it.
    *
-   * {@link module} is resolved from the generated vocabulary source file
+   * `module` is resolved from the generated vocabulary source file
    * and imported dynamically at decode time.
    */
   preprocessors?: PropertyPreprocessorSchema[];

--- a/packages/vocab-tools/src/schema.ts
+++ b/packages/vocab-tools/src/schema.ts
@@ -122,6 +122,33 @@ export interface PropertySchemaBase {
      */
     inherit: true;
   };
+
+  /**
+   * Preprocessors for this property.  Each preprocessor receives an expanded
+   * JSON-LD property value and may return a vocabulary object matching the
+   * property's declared range, `undefined` when it did not handle the value,
+   * or an `Error` when it recognized the value but failed while converting it.
+   *
+   * {@link module} is resolved from the generated vocabulary source file
+   * and imported dynamically at decode time.
+   */
+  preprocessors?: PropertyPreprocessorSchema[];
+}
+
+/**
+ * A schema for a property preprocessor that normalizes wire-level values
+ * before the generated range decoder runs.
+ */
+export interface PropertyPreprocessorSchema {
+  /**
+   * Module specifier resolved from the generated vocabulary source file.
+   */
+  module: string;
+
+  /**
+   * The name of the exported function in the module.
+   */
+  function: string;
 }
 
 export type PropertySchemaTyping = {

--- a/packages/vocab-tools/src/schema.yaml
+++ b/packages/vocab-tools/src/schema.yaml
@@ -132,6 +132,7 @@ $defs:
                 Module specifier resolved from the generated vocabulary
                 source file.
               type: string
+              minLength: 1
             function:
               description: The name of the exported function in the module.
               type: string

--- a/packages/vocab-tools/src/schema.yaml
+++ b/packages/vocab-tools/src/schema.yaml
@@ -122,7 +122,7 @@ $defs:
           failed while converting it.
 
           `module` is resolved from the generated vocabulary source file
-          and imported dynamically at decode time.
+          and imported statically at the top of the generated file.
         type: array
         items:
           type: object

--- a/packages/vocab-tools/src/schema.yaml
+++ b/packages/vocab-tools/src/schema.yaml
@@ -113,6 +113,32 @@ $defs:
               Whether the embedded context should be the same as the context of
               the enclosing document.
             const: true
+      preprocessors:
+        description: >-
+          Preprocessors for this property.  Each preprocessor receives an
+          expanded JSON-LD property value and may return a vocabulary object
+          matching the property's declared range, `undefined` when it did not
+          handle the value, or an `Error` when it recognized the value but
+          failed while converting it.
+
+          `module` is resolved from the generated vocabulary source file
+          and imported dynamically at decode time.
+        type: array
+        items:
+          type: object
+          properties:
+            module:
+              description: >-
+                Module specifier resolved from the generated vocabulary
+                source file.
+              type: string
+            function:
+              description: The name of the exported function in the module.
+              type: string
+              pattern: "^[a-zA-Z_$][a-zA-Z0-9_$]*$"
+          required:
+          - module
+          - function
     required:
     - singularName
     - uri

--- a/packages/vocab/src/mod.ts
+++ b/packages/vocab/src/mod.ts
@@ -53,6 +53,7 @@ export * from "./actor.ts";
 export * from "./constants.ts";
 export * from "./handle.ts";
 export * from "./lookup.ts";
+export * from "./preprocessors.ts";
 export * from "./type.ts";
 export * from "./vocab.ts";
 export { LanguageString } from "@fedify/vocab-runtime";

--- a/packages/vocab/src/object.yaml
+++ b/packages/vocab/src/object.yaml
@@ -137,6 +137,9 @@ properties:
     (vertical) and should be suitable for presentation at a small size.
   range:
   - "https://www.w3.org/ns/activitystreams#Image"
+  preprocessors:
+  - module: ./preprocessors.ts
+    function: normalizeLinkToImage
 
 - pluralName: images
   singularName: image
@@ -149,6 +152,9 @@ properties:
     limitations assumed.
   range:
   - "https://www.w3.org/ns/activitystreams#Image"
+  preprocessors:
+  - module: ./preprocessors.ts
+    function: normalizeLinkToImage
 
 - pluralName: replyTargets
   singularName: replyTarget

--- a/packages/vocab/src/preprocessors.ts
+++ b/packages/vocab/src/preprocessors.ts
@@ -41,9 +41,7 @@ export const normalizeLinkToImage: PropertyPreprocessor<Image> = async (
     id: link.id,
     url: link.href,
     mediaType: link.mediaType,
-    names: link.names?.length != null && link.names.length > 0
-      ? link.names
-      : undefined,
+    names: link.names != null && link.names.length > 0 ? link.names : undefined,
     width: link.width,
     height: link.height,
   });

--- a/packages/vocab/src/preprocessors.ts
+++ b/packages/vocab/src/preprocessors.ts
@@ -1,6 +1,18 @@
 import type { PropertyPreprocessor } from "@fedify/vocab-runtime";
 import { Image, Link } from "./vocab.ts";
 
+/**
+ * A property preprocessor that normalizes Link values to Image objects.
+ *
+ * When an `icon` or `image` property on a vocabulary object contains an
+ * explicit ActivityStreams `Link` rather than an `Image`, this preprocessor
+ * converts it into an `Image` by mapping `href` to `url`, copying
+ * `mediaType`, `name`, `width`, and `height`, and discarding the rest.
+ *
+ * If the value is not a Link, or the Link has no `href`, it returns
+ * `undefined` so the normal range decoder continues.
+ * @since 2.3.0
+ */
 export const normalizeLinkToImage: PropertyPreprocessor<Image> = async (
   value,
   context,

--- a/packages/vocab/src/preprocessors.ts
+++ b/packages/vocab/src/preprocessors.ts
@@ -1,0 +1,37 @@
+import type { PropertyPreprocessor } from "@fedify/vocab-runtime";
+import { Image, Link } from "./vocab.ts";
+
+export const normalizeLinkToImage: PropertyPreprocessor<Image> = async (
+  value,
+  context,
+) => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    Array.isArray(value) ||
+    !("@type" in value) ||
+    !Array.isArray(value["@type"]) ||
+    !value["@type"].includes("https://www.w3.org/ns/activitystreams#Link")
+  ) {
+    return undefined;
+  }
+
+  let link: Link;
+  try {
+    link = await Link.fromJsonLd(value, context);
+  } catch (error) {
+    return error instanceof Error ? error : new Error(String(error));
+  }
+
+  if (link.href == null) return undefined;
+
+  return new Image({
+    url: link.href,
+    mediaType: link.mediaType,
+    names: link.names?.length != null && link.names.length > 0
+      ? link.names
+      : undefined,
+    width: link.width,
+    height: link.height,
+  });
+};

--- a/packages/vocab/src/preprocessors.ts
+++ b/packages/vocab/src/preprocessors.ts
@@ -38,6 +38,7 @@ export const normalizeLinkToImage: PropertyPreprocessor<Image> = async (
   if (link.href == null) return undefined;
 
   return new Image({
+    id: link.id,
     url: link.href,
     mediaType: link.mediaType,
     names: link.names?.length != null && link.names.length > 0

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1993,6 +1993,26 @@ test("Object.fromJsonLd() decodes compact icon id with relative id and baseUrl",
   );
 });
 
+test("Object.fromJsonLd() resolves compact icon id against baseUrl for did id", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "id": "did:plc:example",
+    "content": "Hello",
+    "icon": "/icons/icon.png",
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+    baseUrl: new URL("https://example.com/notes/1"),
+  });
+  deepStrictEqual(obj.id?.href, "did:plc:example");
+  deepStrictEqual(
+    obj.iconId?.href,
+    "https://example.com/icons/icon.png",
+  );
+});
+
 test(
   "Object.getIcon() resolves relative Link href without id via cached re-parse",
   async () => {
@@ -2015,6 +2035,36 @@ test(
     // getIcon() is called WITHOUT explicit baseUrl — the accessor
     // should reuse the baseUrl that was set during fromJsonLd().
     const icon = await obj.getIcon();
+    deepStrictEqual(
+      icon?.url?.href,
+      "https://example.com/icons/star.png",
+    );
+    deepStrictEqual(icon?.mediaType, "image/png");
+  },
+);
+
+test(
+  "Object.getIcon() resolves cached relative Link href against baseUrl for did id",
+  async () => {
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "id": "did:plc:example",
+      "content": "Hello",
+      "icon": {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "type": "Link",
+        "href": "/icons/star.png",
+        "mediaType": "image/png",
+      },
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: new URL("https://example.com/notes/1"),
+    });
+    const icon = await obj.getIcon();
+    deepStrictEqual(obj.id?.href, "did:plc:example");
     deepStrictEqual(
       icon?.url?.href,
       "https://example.com/icons/star.png",

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1922,6 +1922,57 @@ test("Object.fromJsonLd() normalizes Link icon with relative URL", async () => {
   );
 });
 
+test(
+  "Object.fromJsonLd() normalizes Link icon with relative id and baseUrl",
+  async () => {
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "id": "/notes/1",
+      "content": "Hello",
+      "icon": {
+        "type": "Link",
+        "href": "/icons/icon.png",
+      },
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: new URL("https://example.com/"),
+    });
+    const icon = await obj.getIcon();
+    deepStrictEqual(obj.id?.href, "https://example.com/notes/1");
+    deepStrictEqual(
+      icon?.url?.href,
+      "https://example.com/icons/icon.png",
+    );
+  },
+);
+
+test("Object.fromJsonLd() decodes Image icon with relative id and baseUrl", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "id": "/notes/1",
+    "content": "Hello",
+    "icon": {
+      "type": "Image",
+      "url": "/icons/icon.png",
+    },
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+    baseUrl: new URL("https://example.com/"),
+  });
+  const icon = await obj.getIcon();
+  deepStrictEqual(obj.id?.href, "https://example.com/notes/1");
+  deepStrictEqual(
+    icon?.url?.href,
+    "https://example.com/icons/icon.png",
+  );
+});
+
 test("Object.fromJsonLd() normalizes multiple Link icons", async () => {
   const json = {
     "@context": "https://www.w3.org/ns/activitystreams",

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1844,6 +1844,107 @@ test("Person.fromJsonLd() with relative URLs and baseUrl", async () => {
   );
 });
 
+test("Object.fromJsonLd() normalizes Link icon to Image", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "content": "Hello",
+    "icon": {
+      "type": "Link",
+      "href": "https://example.com/icon.png",
+      "mediaType": "image/png",
+      "name": "Icon",
+      "width": 64,
+      "height": 64,
+    },
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+  });
+  const icon = await obj.getIcon();
+  deepStrictEqual(
+    icon?.url?.href,
+    "https://example.com/icon.png",
+  );
+  deepStrictEqual(icon?.mediaType, "image/png");
+  deepStrictEqual(icon?.names, ["Icon"]);
+  deepStrictEqual(icon?.width, 64);
+  deepStrictEqual(icon?.height, 64);
+});
+
+test("Object.fromJsonLd() normalizes Link image to Image", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "content": "Hello",
+    "image": {
+      "type": "Link",
+      "href": "https://example.com/banner.png",
+      "mediaType": "image/png",
+      "width": 800,
+      "height": 200,
+    },
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+  });
+  const images = [];
+  for await (const img of obj.getImages()) {
+    images.push(img);
+  }
+  deepStrictEqual(images[0]?.url?.href, "https://example.com/banner.png");
+  deepStrictEqual(images[0]?.mediaType, "image/png");
+  deepStrictEqual(images[0]?.width, 800);
+  deepStrictEqual(images[0]?.height, 200);
+});
+
+test("Object.fromJsonLd() normalizes Link icon with relative URL", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "id": "https://example.com/notes/1",
+    "content": "Hello",
+    "icon": {
+      "type": "Link",
+      "href": "/icons/icon.png",
+    },
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+  });
+  const icon = await obj.getIcon();
+  deepStrictEqual(
+    icon?.url?.href,
+    "https://example.com/icons/icon.png",
+  );
+});
+
+test("Object.fromJsonLd() normalizes multiple Link icons", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "content": "Hello",
+    "icon": [
+      { "type": "Link", "href": "https://example.com/a.png" },
+      { "type": "Image", "url": "https://example.com/b.png" },
+    ],
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+  });
+  const icons = [];
+  for await (const i of obj.getIcons()) {
+    icons.push(i);
+  }
+  deepStrictEqual(icons.length, 2);
+  deepStrictEqual(icons[0]?.url?.href, "https://example.com/a.png");
+  deepStrictEqual(icons[1]?.url?.href, "https://example.com/b.png");
+});
+
 test("FEP-fe34: Trust tracking in object construction", async () => {
   // Test that objects created with embedded objects have trust set
   const note = new Note({

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1993,6 +1993,26 @@ test("Object.fromJsonLd() decodes compact icon id with relative id and baseUrl",
   );
 });
 
+test("Object.fromJsonLd() resolves compact icon id against document base", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "id": "../notes/1",
+    "content": "Hello",
+    "icon": "icon.png",
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+    baseUrl: new URL("https://example.com/outbox/page.json"),
+  });
+  deepStrictEqual(obj.id?.href, "https://example.com/outbox/notes/1");
+  deepStrictEqual(
+    obj.iconId?.href,
+    "https://example.com/outbox/icon.png",
+  );
+});
+
 test("Object.fromJsonLd() resolves compact icon id against baseUrl for did id", async () => {
   const json = {
     "@context": "https://www.w3.org/ns/activitystreams",
@@ -2040,6 +2060,33 @@ test(
       "https://example.com/icons/star.png",
     );
     deepStrictEqual(icon?.mediaType, "image/png");
+  },
+);
+
+test(
+  "Object.fromJsonLd() resolves Link href against document base, not object id",
+  async () => {
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "id": "../notes/1",
+      "content": "Hello",
+      "icon": {
+        "type": "Link",
+        "href": "icon.png",
+      },
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: new URL("https://example.com/outbox/page.json"),
+    });
+    const icon = await obj.getIcon();
+    deepStrictEqual(obj.id?.href, "https://example.com/outbox/notes/1");
+    deepStrictEqual(
+      icon?.url?.href,
+      "https://example.com/outbox/icon.png",
+    );
   },
 );
 

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1945,6 +1945,45 @@ test("Object.fromJsonLd() normalizes multiple Link icons", async () => {
   deepStrictEqual(icons[1]?.url?.href, "https://example.com/b.png");
 });
 
+test("Object.getIcon() normalizes fetched Link document to Image", async () => {
+  const linkDocUrl = "https://example.com/icons/avatar-link";
+  const linkDoc = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    type: "Link",
+    href: "https://example.com/avatars/user.png",
+    mediaType: "image/png",
+    width: 128,
+    height: 128,
+  };
+  const docLoader = async (url: string) => {
+    if (url === linkDocUrl) {
+      return {
+        document: linkDoc,
+        documentUrl: url,
+        contextUrl: null,
+      };
+    }
+    return await mockDocumentLoader(url);
+  };
+
+  const person = new Person({
+    id: new URL("https://example.com/ap/actors/test-user"),
+    icon: new URL(linkDocUrl),
+  });
+
+  const icon = await person.getIcon({
+    documentLoader: docLoader,
+    contextLoader: mockDocumentLoader,
+  });
+  deepStrictEqual(
+    icon?.url?.href,
+    "https://example.com/avatars/user.png",
+  );
+  deepStrictEqual(icon?.mediaType, "image/png");
+  deepStrictEqual(icon?.width, 128);
+  deepStrictEqual(icon?.height, 128);
+});
+
 test("FEP-fe34: Trust tracking in object construction", async () => {
   // Test that objects created with embedded objects have trust set
   const note = new Note({

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1973,6 +1973,26 @@ test("Object.fromJsonLd() decodes Image icon with relative id and baseUrl", asyn
   );
 });
 
+test("Object.fromJsonLd() decodes compact icon id with relative id and baseUrl", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "id": "/notes/1",
+    "content": "Hello",
+    "icon": "/icons/icon.png",
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+    baseUrl: new URL("https://example.com/"),
+  });
+  deepStrictEqual(obj.id?.href, "https://example.com/notes/1");
+  deepStrictEqual(
+    obj.iconId?.href,
+    "https://example.com/icons/icon.png",
+  );
+});
+
 test(
   "Object.getIcon() resolves relative Link href without id via cached re-parse",
   async () => {

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -2052,6 +2052,57 @@ test(
   },
 );
 
+test(
+  "Object.fromJsonLd() handles blank node @id without baseUrl",
+  () => {
+    const obj = Object.fromJsonLd({
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "id": "_:b0",
+    }, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+    });
+    // Blank node identifier without baseUrl must not throw.
+    return obj.then((o) => deepStrictEqual(o.id, null));
+  },
+);
+
+test(
+  "Object.getAttachments() resolves relative url via stored _baseUrl",
+  async () => {
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "content": "Hello",
+      "attachment": {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "type": "Document",
+        "url": "/files/report.pdf",
+        "mediaType": "application/pdf",
+      },
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: new URL("https://example.com/"),
+    });
+    // getAttachments() without explicit baseUrl should use stored _baseUrl.
+    const attachments = [];
+    for await (const a of obj.getAttachments()) {
+      attachments.push(a);
+    }
+    deepStrictEqual(attachments.length, 1);
+    // deno-lint-ignore no-explicit-any
+    const doc = attachments[0] as any;
+    deepStrictEqual(
+      doc?.url?.href,
+      "https://example.com/files/report.pdf",
+    );
+    deepStrictEqual(doc?.mediaType, "application/pdf");
+  },
+);
+
 test("Object.fromJsonLd() normalizes multiple Link icons", async () => {
   const json = {
     "@context": "https://www.w3.org/ns/activitystreams",

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -2013,6 +2013,23 @@ test("Object.fromJsonLd() resolves compact icon id against document base", async
   );
 });
 
+test("Object.fromJsonLd() skips blank node compact icon id", async () => {
+  const json = {
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "type": "Note",
+    "id": "/notes/1",
+    "content": "Hello",
+    "icon": { "@id": "_:b0" },
+  };
+  const obj = await Object.fromJsonLd(json, {
+    documentLoader: mockDocumentLoader,
+    contextLoader: mockDocumentLoader,
+    baseUrl: new URL("https://example.com/"),
+  });
+  deepStrictEqual(obj.id?.href, "https://example.com/notes/1");
+  deepStrictEqual(obj.iconId, null);
+});
+
 test("Object.fromJsonLd() resolves compact icon id against baseUrl for did id", async () => {
   const json = {
     "@context": "https://www.w3.org/ns/activitystreams",

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -1973,6 +1973,67 @@ test("Object.fromJsonLd() decodes Image icon with relative id and baseUrl", asyn
   );
 });
 
+test(
+  "Object.getIcon() resolves relative Link href without id via cached re-parse",
+  async () => {
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "content": "Hello",
+      "icon": {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "type": "Link",
+        "href": "/icons/star.png",
+        "mediaType": "image/png",
+      },
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: new URL("https://example.com/"),
+    });
+    // getIcon() is called WITHOUT explicit baseUrl — the accessor
+    // should reuse the baseUrl that was set during fromJsonLd().
+    const icon = await obj.getIcon();
+    deepStrictEqual(
+      icon?.url?.href,
+      "https://example.com/icons/star.png",
+    );
+    deepStrictEqual(icon?.mediaType, "image/png");
+  },
+);
+
+test(
+  "Object.getIcon() ignores mutation of caller's baseUrl after fromJsonLd()",
+  async () => {
+    const origBaseUrl = new URL("https://example.com/");
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "content": "Hello",
+      "icon": {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        "type": "Link",
+        "href": "/icons/star.png",
+        "mediaType": "image/png",
+      },
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: origBaseUrl,
+    });
+    // Mutate the caller's URL after construction.
+    origBaseUrl.href = "https://attacker.example/";
+    const icon = await obj.getIcon();
+    deepStrictEqual(
+      icon?.url?.href,
+      "https://example.com/icons/star.png",
+    );
+    deepStrictEqual(icon?.mediaType, "image/png");
+  },
+);
+
 test("Object.fromJsonLd() normalizes multiple Link icons", async () => {
   const json = {
     "@context": "https://www.w3.org/ns/activitystreams",

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -2034,6 +2034,24 @@ test(
   },
 );
 
+test(
+  "Object.fromJsonLd() does not resolve blank node @id against baseUrl",
+  async () => {
+    const json = {
+      "@context": "https://www.w3.org/ns/activitystreams",
+      "type": "Note",
+      "id": "_:b0",
+    };
+    const obj = await Object.fromJsonLd(json, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+      baseUrl: new URL("https://example.com/"),
+    });
+    // Blank node identifiers must not be resolved against baseUrl.
+    deepStrictEqual(obj.id, null);
+  },
+);
+
 test("Object.fromJsonLd() normalizes multiple Link icons", async () => {
   const json = {
     "@context": "https://www.w3.org/ns/activitystreams",


### PR DESCRIPTION
## Background

Fedify needs a way to normalize wire-level ActivityStreams shapes before the generated vocabulary decoder applies the declared TypeScript-facing range of a property. This came up while investigating #790: ActivityStreams 2.0 allows `Object.icon` and `Object.image` to contain either `Image` or `Link`, but Fedify has exposed those properties as `Image`-oriented APIs since 0.4.0. Restoring `Image | Link` at the TypeScript API level should wait for Fedify 3.0, so for the current major version we need a narrower compatibility path.

Closes #792 and lays the groundwork for fixing #790.

## What changed

### @fedify/vocab-runtime

New types in *packages/vocab-runtime/src/preprocessor.ts*:

- `Json` — a recursive JSON type alias for describing expanded JSON-LD values
- `PropertyPreprocessorContext` — the context a preprocessor receives (`documentLoader`, `contextLoader`, `tracerProvider`, `baseUrl`)
- `PropertyPreprocessor<T>` — a generic function type that receives an expanded JSON-LD property value and returns `T | undefined | Error | Promise<T | undefined | Error>`

### @fedify/vocab-tools

Property schemas now support a `preprocessors` field in *packages/vocab-tools/src/schema.yaml* and *packages/vocab-tools/src/schema.ts*. Each entry specifies a `module` and a `function`. The module path is resolved from the generated vocabulary source file and imported dynamically at decode time.

Generated decoders now run preprocessors before the normal range decoder for each expanded JSON-LD property value. The preprocessor contract:

- Return a vocabulary object matching the property's declared range → the value is used, normal decoder is skipped
- Return `undefined` → the normal range decoder continues
- Return an `Error` → decoding fails immediately

Both the main `fromJsonLd()` decoder path (in *packages/vocab-tools/src/codec.ts*) and the remote-fetch `#<property>_fromJsonLd` helper path (in *packages/vocab-tools/src/property.ts*) now emit preprocessor blocks.

### @fedify/vocab

New file *packages/vocab/src/preprocessors.ts* provides `normalizeLinkToImage`, a property preprocessor that converts explicit ActivityStreams `Link` objects into `Image` objects during decoding. It checks for expanded `@type` arrays containing the Link URI, parses the Link via `Link.fromJsonLd()`, and maps `href`, `mediaType`, `name`, `width`, and `height` onto an `Image` instance. If `href` is missing the preprocessor returns `undefined`.

The `icon` and `image` properties in *packages/vocab/src/object.yaml* now declare this preprocessor. The public TypeScript API remains `Image`-oriented.

## Tests

Five regression tests added to *packages/vocab/src/vocab.test.ts*:

- Embedded Link icon normalized to Image
- Embedded Link image normalized to Image
- Link icon with relative URL (base URL resolution)
- Mixed Link + Image icon array
- URL-backed Link icon fetched and normalized (covers the remote-fetch path)

All 30,428 existing tests continue to pass on Deno.

## AI disclosure

This work was developed with AI assistance. All commits carry `Assisted-by: OpenCode:deepseek-v4-pro` trailers, and the final commit additionally carries `Assisted-by: Codex:gpt-5.5` for the preprocessor expansion fix identified during code review.